### PR TITLE
[fix] correct Form event name in MCP server guide

### DIFF
--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -226,7 +226,7 @@ How do I apply multiple filters to a DHTMLX Grid?
 How do I add custom validation to DHTMLX Form? Use the docs.
 ~~~
 ~~~
-How do I get all form values as an object and handle the send event in DHTMLX Form?
+How do I get all form values as an object and handle the afterSend event in DHTMLX Form?
 ~~~
 
 **Chart**


### PR DESCRIPTION
- replaced non-existent "send event" with the actual "afterSend" event name