### PR TITLE
[add] Grid accessibility and keyboard navigation docs

### DIFF
--- a/docs/common_features/accessibility_support.md
+++ b/docs/common_features/accessibility_support.md
@@ -32,14 +32,18 @@ There are special attributes used in the markup of DHTMLX Suite widgets that mak
 
 ### Grid
 
-There are **roles** and **attributes** for elements of grid, sorting, filters, editable cells to enable screen readers to interpret and navigate the columns and rows of the grid (enabled by default). Custom content should be marked manually.
+There are **roles** and **attributes** for elements of grid, sorting, filters, editable cells to enable screen readers to interpret and navigate the columns and rows of the grid (enabled by default). The semantics are always present and there is no flag to disable them. Custom content should be marked manually.
 
 You can find the following **roles** and **attributes** in the DOM:
 
-- role: *grid*, *rowgroup*, *row*, *columnheader*, *gridcell*, *button*
-- aria attributes: *label*, *rowcount*, *colcount*, *rowindex*, *colindex*, *aria-sort*.
+- role: *grid* (or *treegrid* in the `type: "tree"` mode), *rowgroup*, *row*, *columnheader*, *gridcell*, *button*
+- aria attributes: *label*, *rowcount*, *colcount*, *rowindex*, *colindex*, *aria-sort*, *aria-selected*, *aria-readonly*, *aria-multiselectable*, and — for tree rows — *aria-level* and *aria-expanded*.
 
-Role presentation and aria-hidden are used to hide redundant content from the accessibility tree.
+In-place editors and header/footer filters get an accessible name derived from the column header text. Role presentation and aria-hidden are used to hide redundant content (resizers, sort icons, drag ghosts, the selection overlay) from the accessibility tree.
+
+:::info
+For the complete picture — the ARIA model, the keyboard zones (header/body/footer), the focus model, and configuration recipes — see the dedicated [Grid accessibility](grid/accessibility.md) guide.
+:::
 
 ### Chart
 
@@ -72,10 +76,10 @@ Role presentation and aria-hidden are used to hide redundant markup from the acc
 
 All DHTMLX Suite widgets are provided with a keyboard navigation support. It allows using a Suite-based app without a mouse pointer. Basic rules include:
 
-- the "tab" key is used to navigate between widgets and clickable areas of the widgets
-- the "esc" key closes windows and editors
-- the "enter" is used to open and hide drop-down lists of select controls
-- the arrow keys are used to move selection or change active elements within widgets
+- the <kbd>Tab</kbd> key is used to navigate between widgets and clickable areas of the widgets
+- the <kbd>Esc</kbd> key closes windows and editors
+- the <kbd>Enter</kbd> is used to open and hide drop-down lists of select controls
+- the <kbd>Arrow</kbd> keys are used to move selection or change active elements within widgets
 
 :::info
 For the full list of built-in hotkeys, refer to the **Keyboard Navigation** articles of the following widgets:

--- a/docs/grid/accessibility.md
+++ b/docs/grid/accessibility.md
@@ -1,0 +1,254 @@
+---
+sidebar_label: Accessibility
+title: JavaScript Grid - Accessibility
+description: You can learn about accessibility and keyboard navigation in DHTMLX Grid in the documentation of the DHTMLX JavaScript UI library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX Suite.
+---
+
+# Accessibility in DHTMLX Grid
+
+DHTMLX Grid is built to be operated entirely from the keyboard and to expose its structure and state to assistive technology. WAI-ARIA semantics are part of the rendered markup, and a single, coherent focus model spans the header, body, and footer. The semantics are always present — there is **no** configuration flag to disable them.
+
+## Capabilities
+
+| Area | Support |
+| ---- | ------- |
+| Keyboard operation | Full: cell navigation, editing, sorting, range selection, tree expand/collapse, and clipboard all have keyboard equivalents |
+| WAI-ARIA semantics | Built-in (`grid` / `treegrid` model), enabled always — no opt-in flag |
+| Focus model | A single tab stop per zone; focus moves between header, body, and footer |
+| Selection model | Two modes: single-cell/row (`selection`) and spreadsheet-style range (`blockSelection`) |
+| High-contrast display | Light and dark high-contrast themes (`contrast-light` / `contrast-dark`) |
+
+## Covered areas
+
+This documentation covers the Grid widget:
+
+- the **data body** — cells and rows, including tree mode (`type: "tree"`)
+- the **column header** — sortable headers and in-header filters
+- the **footer** — summaries and footer filters
+- the **inline editors**
+- the keyboard model that connects these zones.
+
+As with any embeddable component, the accessibility of the final page also depends on the host application (see [Host-page responsibilities](#host-page-responsibilities)).
+
+## WAI-ARIA support
+
+WAI-ARIA roles and attributes are added to the component markup automatically and are **on by default** — there is no flag to turn them off. The Grid exposes itself to assistive technology as an interactive grid (or treegrid) of rows and cells, with a separate group for the header and footer. The semantics are applied per structural part of the widget, so each part is announced with the correct role and state.
+
+### Grid container
+
+The following table lists the container role and the grid-wide attributes applied to the root grid element, which describe the grid as a whole:
+
+| Selector | Role / attribute | Purpose |
+| -------- | ---------------- | ------- |
+| `.dhx_grid` | `role="grid"` | Standard grid |
+| `.dhx_grid` | `role="treegrid"` | TreeGrid (`type: "tree"`) |
+| `.dhx_grid` | `aria-rowcount` | Total number of data rows |
+| `.dhx_grid` | `aria-colcount` | Number of visible columns |
+| `.dhx_grid` | `aria-readonly` | `"true"` when the grid is not editable |
+| `.dhx_grid` | `aria-multiselectable` | `"true"` when multi-selection is enabled |
+
+### Rows and cells
+
+The following table lists the roles and the position and state attributes applied to data rows and cells, which let assistive technology announce where the user is:
+
+| Selector | Role / attribute | Purpose |
+| -------- | ---------------- | ------- |
+| Data row | `role="row"` | A row of the grid |
+| Data row | `aria-rowindex` | 1-based row position |
+| Data cell | `role="gridcell"` | A data cell |
+| Data cell | `aria-colindex` | 1-based column position |
+| Data cell | `aria-readonly` | `"true"` when the cell is not editable |
+| Data cell | `aria-selected` | Selection state of the cell |
+
+### Tree (TreeGrid) rows
+
+The following table lists the hierarchy attributes applied to tree rows and the role on the expand/collapse toggle in TreeGrid mode (`type: "tree"`), which convey the row's depth and open/closed state:
+
+| Selector | Role / attribute | Purpose |
+| -------- | ---------------- | ------- |
+| Tree row | `aria-level` | Depth of the row in the hierarchy |
+| Tree row | `aria-expanded` | Open/closed state of a branch with children |
+| Tree row | `aria-selected` | Selection state of the row |
+| Expand/collapse toggle | `role="button"` + `aria-label` | `"Expand group"` / `"Collapse group"` |
+
+### Header and footer
+
+The following table lists the roles and attributes applied to the header and footer groups, rows, and cells, which expose the column headers, sort state, and filter controls:
+
+| Selector | Role / attribute | Purpose |
+| -------- | ---------------- | ------- |
+| Header/footer group | `role="rowgroup"` + `aria-rowcount` | Groups the header or footer rows |
+| Header/footer row | `role="row"` + `aria-rowindex` | A header or footer row |
+| Header cell | `role="columnheader"` + `aria-sort` | Column header; `aria-sort` is `none` / `ascending` / `descending` |
+| Footer cell | `role="gridcell"` + `aria-colindex` | A footer (summary) cell |
+| Content (filter) cell | `role="gridcell"` | Header/footer cell hosting a filter control |
+| Sort affordance | `role="button"` + `aria-label="Sort by …"` | Keyboard- and pointer-activatable sort trigger |
+
+### Editors and filters
+
+In-place editor inputs and header/footer filters receive an accessible name derived from column header text, so screen-reader users hear which column they are editing or filtering. For example, a filter input is labeled `"Filter {column}"` and a date filter `"Filter by date: {column}"`.
+
+### Hidden and decorative elements
+
+Resizer grips, sort icons, sort-order counters, drag ghosts, drop indicators, and the selection overlay are removed from the accessibility tree with `aria-hidden="true"` / `role="presentation"`, so screen readers are not cluttered with redundant markup.
+
+## Selection modes
+
+The keyboard behavior of the body depends on which selection system is enabled. The two are independent and drive different ARIA output and shortcut semantics.
+
+### 1. Cell / row selection — selection
+
+A single active cell (or row) moves with the arrow keys. This populates `aria-selected` on the focused cell or row. Extending the selection with <kbd>Shift</kbd> is enabled only when `multiselection: true`; without it, <kbd>Shift</kbd>+arrow moves the active cell.
+
+~~~jsx
+// Single active cell, navigable with arrows / Tab / Home / End / Page Up·Down
+const grid = new dhx.Grid("grid_container", {
+    columns: [/* ... */],
+    data: dataset,
+    selection: "complex", // "cell" | "row" | "complex"
+    multiselection: true, // enables Shift+Arrow multi-select
+    keyNavigation: true   // default
+});
+~~~
+
+| `selection` value | Meaning |
+| --- | --- |
+| `"cell"` | One active cell; <kbd>Shift</kbd>+arrow extends when `multiselection: true` |
+| `"row"` | One active row; arrows move the whole row, `aria-selected` is on the row |
+| `"complex"` | Cell- and row-style selection combined |
+| `true` | Equivalent to cell selection |
+| *falsy / unset* | Selection (and `aria-selected`) disabled |
+
+### 2. Range / block selection — blockSelection
+
+Spreadsheet-style rectangular ranges. The arrow keys move the range anchor; <kbd>Shift</kbd>+arrows grow or shrink the rectangle; <kbd>Delete</kbd> clears the range (when editing is enabled). This applies in **"range"** mode.
+
+~~~jsx
+// Google-Sheets-style range selection
+const grid = new dhx.Grid("grid_container", {
+    columns: [/* ... */],
+    data: dataset,
+    blockSelection: true, // range mode (Shift+Arrow grows the rectangle)
+    editable: true,       // allows Delete to clear the range
+    keyNavigation: true
+});
+~~~
+
+| `blockSelection` value | Mode | Keyboard effect |
+| ---------------------- | ---- | --------------- |
+| `true` | range | Arrows move the range; <kbd>Shift</kbd>+arrows extend the rectangle; <kbd>Delete</kbd> clears it |
+
+Both systems coexist with the same navigation keys; the Grid responds to whichever selection system is active.
+
+## Keyboard navigation
+
+Keyboard navigation is on by default (`keyNavigation: true`); set `keyNavigation: false` to opt out. Focus enters the Grid through hidden focus sentinels placed before the header and after the footer, which direct it into the correct zone. Within each zone a single cell is the tab stop, and the arrow keys move between cells from there.
+
+Shortcuts are organized into **zones** — body, header, footer — and resolved by where focus currently is. The full reference is in the [Keyboard navigation](grid/configuration.md#keyboard-navigation) article; the tables below summarize it.
+
+### Grid body
+
+| Keys | Action | Selection mode |
+| ---- | ------ | -------------- |
+| <kbd>↑</kbd> / <kbd>↓</kbd> / <kbd>←</kbd> / <kbd>→</kbd> | Move the selected cell one row/column (<kbd>↑</kbd> from the first row enters the header; <kbd>↓</kbd> from the last row enters the footer when a footer exists) | both |
+| <kbd>Ctrl</kbd> + arrow | Jump the selection to the first/last cell in that direction | both |
+| <kbd>Shift</kbd> + arrow | Extend the selection by one cell | `selection` with `multiselection: true`, or `blockSelection` range |
+| <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + arrow | Extend the selection to the edge | as above |
+| <kbd>Home</kbd> / <kbd>End</kbd> | Move to the first / last column of the current row | both |
+| <kbd>Ctrl</kbd> + <kbd>Home</kbd> / <kbd>Ctrl</kbd> + <kbd>End</kbd> | Move to the first / last cell of the grid | both |
+| <kbd>Shift</kbd> + <kbd>Home</kbd> / <kbd>End</kbd>, <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Home</kbd> / <kbd>End</kbd> | Extend the selection to the row/grid extent | extend-capable modes |
+| <kbd>Page Up</kbd> / <kbd>Page Down</kbd> | Move the selected cell up / down by one page of visible rows | both |
+| <kbd>Shift</kbd> + <kbd>Page Up</kbd> / <kbd>Page Down</kbd> | Extend the selection by one page | extend-capable modes |
+| <kbd>Enter</kbd> | Open the editor (or toggle a boolean cell); when editing, commit and close | requires `editable` |
+| <kbd>F2</kbd> | Open the editor of the selected cell (non-boolean) | requires `editable` |
+| <kbd>Space</kbd> | Toggle a boolean cell | requires `editable` |
+| <kbd>Escape</kbd> | Cancel editing without saving | requires `editable` |
+| <kbd>Tab</kbd> / <kbd>Shift</kbd> + <kbd>Tab</kbd> | Move to the next / previous cell, wrapping rows; exits to the footer / header at the ends | both |
+| <kbd>Delete</kbd> | Clear the selected range | `blockSelection` range mode + `editable` |
+| <kbd>Ctrl</kbd> + <kbd>Z</kbd> / <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Z</kbd> | Undo / Redo | History module |
+| <kbd>Ctrl</kbd> + <kbd>Enter</kbd> | Expand / collapse the row (`type: "tree"`) | TreeGrid |
+| <kbd>→</kbd> / <kbd>←</kbd> (tree column) | Expand / collapse a branch, or move to first child / parent | TreeGrid |
+
+### Header
+
+| Keys | Action |
+| ---- | ------ |
+| <kbd>←</kbd> / <kbd>→</kbd> | Move between header cells (colspan-aware) |
+| <kbd>↑</kbd> / <kbd>↓</kbd> | Move between header rows (multi-row header); <kbd>↑</kbd> from the first row has no effect, <kbd>↓</kbd> from the last row moves into the body |
+| <kbd>Enter</kbd> / <kbd>Space</kbd> | Sort by the column; on a filter cell, <kbd>Enter</kbd> activates the filter control |
+| <kbd>Shift</kbd> + <kbd>Enter</kbd> | Toggle multi-sort for the column (requires `multiSort`) |
+| <kbd>Tab</kbd> / <kbd>Shift</kbd> + <kbd>Tab</kbd> | Move within the header with row wrapping; exits to the body / out of the grid at the ends |
+| <kbd>Escape</kbd> | Deactivate a filter control (restoring focus to its cell), or return focus to the body |
+
+### Footer
+
+| Keys | Action |
+| ---- | ------ |
+| <kbd>←</kbd> / <kbd>→</kbd> | Move between footer cells (colspan-aware) |
+| <kbd>↑</kbd> / <kbd>↓</kbd> | Move between footer rows (multi-row footer); <kbd>↑</kbd> from the first row moves into the body, <kbd>↓</kbd> from the last row has no effect |
+| <kbd>Enter</kbd> | Activate a footer filter control |
+| <kbd>Tab</kbd> / <kbd>Shift</kbd> + <kbd>Tab</kbd> | Move within the footer with row wrapping; exits the grid / to the body at the ends |
+| <kbd>Escape</kbd> | Deactivate a filter control, or return focus to the body |
+
+:::note
+Navigation is **span-aware**: movement across merged (colspan/rowspan) header and footer cells stays predictable, and the logical navigation row is preserved. When focus reaches an off-screen (virtualized) column, the Grid scrolls it into view automatically.
+:::
+
+## Assistive technology
+
+What the Grid exposes to assistive technology is driven entirely by the ARIA markup above. Rows and cells carry their position (`aria-rowindex` / `aria-colindex`) against the grid totals (`aria-rowcount` / `aria-colcount`), so position is announced even when rows are virtualized. Selection is exposed through `aria-selected`, editability through `aria-readonly`, sort state through `aria-sort`, and — in tree mode (`type: "tree"`) — hierarchy through `aria-level` and `aria-expanded`.
+
+## High contrast and focus
+
+- **High-contrast themes.** Light and dark high-contrast themes ship with the library (`contrast-light` and `contrast-dark`), activated by setting `data-dhx-theme="contrast-light"` or `data-dhx-theme="contrast-dark"`. See the [Themes](/themes/) guide and the [Light High Contrast](themes/contrast_light_theme.md) / [Dark High Contrast](themes/contrast_dark_theme.md) pages for details.
+- **Visible focus.** Focus is tracked per zone by the roving-tabindex model, so the active cell is the single tab stop and moves predictably with the arrow keys.
+
+## Configuration recipes
+
+~~~jsx
+// A. Cell navigation (single active cell)
+new dhx.Grid("grid_container", {
+    columns, data,
+    selection: "complex",
+    multiselection: true, // Shift+Arrow multi-select
+    keyNavigation: true,  // default
+    sortable: true        // default — keyboard sort in headers
+});
+
+// B. Spreadsheet-style range selection
+new dhx.Grid("grid_container", {
+    columns, data,
+    blockSelection: true, // range mode: Shift+Arrow grows the rectangle, Delete clears
+    editable: true
+});
+
+// C. TreeGrid (adds role="treegrid", aria-level, aria-expanded,
+//    and arrow-key expand/collapse)
+new dhx.Grid("grid_container", {
+    columns, data,
+    type: "tree",
+    selection: "complex"
+});
+
+// WAI-ARIA semantics are always emitted — there is no flag to toggle them.
+~~~
+
+Related articles:
+
+- [Keyboard navigation](grid/configuration.md#keyboard-navigation)
+- [keyNavigation](grid/api/grid_keynavigation_config.md)
+- [selection](grid/api/grid_selection_config.md)
+- [blockSelection](grid/api/grid_blockselection_config.md)
+- [TreeGrid mode](grid/treegrid_mode.md)
+
+## Host-page responsibilities
+
+A few accessibility requirements live at the page level, not inside the component. Make sure the host document:
+
+- sets a document language, e.g. `<html lang="en">`;
+- provides a page `<h1>` and wraps the grid in an appropriate landmark (e.g. `<main>`);
+- gives the grid container an accessible name where multiple widgets share a page.
+
+## Reference
+
+- [WAI-ARIA Authoring Practices: Grid / Treegrid](https://www.w3.org/WAI/ARIA/apg/patterns/)

--- a/docs/grid/api/grid_editable_config.md
+++ b/docs/grid/api/grid_editable_config.md
@@ -25,6 +25,10 @@ const grid = new dhx.Grid("grid_container", {
  
 **Related sample**: [Grid. Editing with different editors (combobox, select, multiselect, boolean, date)](https://snippet.dhtmlx.com/w2cdossn)
 
+**Related articles:**
+- [Keyboard navigation](grid/configuration.md#keyboard-navigation)
+- [Grid accessibility](grid/accessibility.md)
+
 @changelog: added in v6.4
 
 [comment]: # (@related:grid/initialization.md#initialize-grid grid/configuration.md#editing-grid-and-separate-columns)

--- a/docs/grid/api/grid_keynavigation_config.md
+++ b/docs/grid/api/grid_keynavigation_config.md
@@ -27,8 +27,8 @@ const grid = new dhx.Grid("grid_container", {
 
 **Related sample**: [Grid. Key navigation](https://snippet.dhtmlx.com/y9kdk0md)
 
-You need to set the [selection](grid/api/grid_selection_config.md) and [editable](grid/api/grid_editable_config.md) properties in the configuration object of Grid to enable all available shortcut keys.  Read the details in the [Key Navigation](grid/configuration.md#keyboard-navigation) article.
+You need to set the [selection](grid/api/grid_selection_config.md) and [editable](grid/api/grid_editable_config.md) properties in the configuration object of Grid to enable all available shortcut keys.  Read the details in the [Key Navigation](grid/configuration.md#keyboard-navigation) article and in the [Grid accessibility](grid/accessibility.md) guide.
 
-@changelog: added in v6.3
+@changelog: added in v6.3; the keyboard navigation model was extended in v9.3.5
 
 [comment]: # (@related: grid/initialization.md#initialize-grid grid/configuration.md#keyboard-navigation)

--- a/docs/grid/api/grid_selection_config.md
+++ b/docs/grid/api/grid_selection_config.md
@@ -27,6 +27,7 @@ When you set `selection:true`, the "complex" mode is applied.
 
 **Related sample**: [Grid. Selection](https://snippet.dhtmlx.com/ad6roqsx)
 
-**Related articles:** 
+**Related articles:**
 - [Selection](grid/configuration.md#selection)
 - [Work with Selection object](grid/usage_selection.md)
+- [Grid accessibility](grid/accessibility.md)

--- a/docs/grid/api/grid_type_config.md
+++ b/docs/grid/api/grid_type_config.md
@@ -24,4 +24,6 @@ const grid = new dhx.Grid("grid_container", {
 
 
 
-**Related article:** [TreeGrid mode](grid/treegrid_mode.md)
+**Related articles:**
+- [TreeGrid mode](grid/treegrid_mode.md)
+- [Grid accessibility](grid/accessibility.md)

--- a/docs/grid/configuration.md
+++ b/docs/grid/configuration.md
@@ -3159,7 +3159,7 @@ For information on working with the History API, read the [Work with History mod
 
 ## Keyboard navigation
 
-DHTMLX Grid provides the keyboard navigation that will help you manipulate your grid faster. Shortcuts are organized into **zones** - the body, header, and footer - and are resolved by where the focus currently is. Focus enters the grid through hidden focus sentinels and moves between the zones with the <kbd>Arrow</kbd> and <kbd>Tab</kbd> keys. For ARIA semantics, the focus model, and configuration recipes, refer to the following guide: [Grid accessibility](grid/accessibility.md).
+DHTMLX Grid provides the keyboard navigation that will help you manipulate your grid faster. 
 
 ### Default shortcut keys
 
@@ -3169,11 +3169,19 @@ The navigation shortcut keys and keys combinations that Grid enables by default 
     <tbody>
         <tr>
             <td><kbd>PageUp</kbd></td>
-            <td>moves the selected cell up by one page of visible rows; when no cell is selected, scrolls Grid up to the height of the visible content</td>
+            <td>scrolls Grid up to the height of the visible content (without change of the selected cell)</td>
         </tr>
         <tr>
             <td><kbd>PageDown</kbd></td>
-            <td>moves the selected cell down by one page of visible rows; when no cell is selected, scrolls Grid down to the height of the visible content</td>
+            <td>scrolls Grid down to the height of the visible content (without change of the selected cell)</td>
+        </tr>
+        <tr>
+            <td><kbd>Home</kbd></td>
+            <td>navigates to the beginning of the Grid content (without change of the selected cell)</td>
+        </tr>
+        <tr>
+            <td><kbd>End</kbd></td>
+            <td>navigates to the end of the Grid content (without change of the selected cell)</td>
         </tr>
         <tr>
             <td><kbd>Ctrl</kbd>+<kbd>Enter</kbd></td>
@@ -3250,28 +3258,12 @@ The list of the shortcut keys and their combinations used for moving selection b
             <td> moves selection to the last horizontal cell</td>
         </tr>
         <tr>
-            <td><kbd>Home</kbd></td>
-            <td>moves selection to the first cell (column) of the current row</td>
-        </tr>
-        <tr>
-            <td><kbd>End</kbd></td>
-            <td>moves selection to the last cell (column) of the current row</td>
-        </tr>
-        <tr>
-            <td><kbd>Ctrl</kbd>+<kbd>Home</kbd></td>
-            <td>moves selection to the first cell of the grid</td>
-        </tr>
-        <tr>
-            <td><kbd>Ctrl</kbd>+<kbd>End</kbd></td>
-            <td>moves selection to the last cell of the grid</td>
-        </tr>
-        <tr>
             <td><kbd>Tab</kbd></td>
-            <td>moves selection to the next horizontal cell or the first cell of the next row; at the end of the grid moves the focus into the footer (when it exists) or out of the grid</td>
+            <td> moves selection to the next horizontal cell or the first cell of the next row</td>
         </tr>
         <tr>
             <td><kbd>Shift</kbd>+<kbd>Tab</kbd></td>
-            <td>moves selection to the previous horizontal cell or to the last cell of the previous row; at the beginning of the grid moves the focus into the header or out of the grid</td>
+            <td> moves selection to the previous horizontal cell or to the first cell of the previous row</td>
         </tr>
     </tbody>
 </table>
@@ -3312,30 +3304,6 @@ The combinations of the shortcut keys listed below do not work when the `selecti
             <td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>ArrowRight</kbd></td>
             <td>moves selection to the last horizontal cell with the change of the selected cells</td>
         </tr>
-        <tr>
-            <td><kbd>Shift</kbd>+<kbd>Home</kbd></td>
-            <td>extends the selection to the first cell of the current row</td>
-        </tr>
-        <tr>
-            <td><kbd>Shift</kbd>+<kbd>End</kbd></td>
-            <td>extends the selection to the last cell of the current row</td>
-        </tr>
-        <tr>
-            <td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Home</kbd></td>
-            <td>extends the selection to the first cell of the grid</td>
-        </tr>
-        <tr>
-            <td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>End</kbd></td>
-            <td>extends the selection to the last cell of the grid</td>
-        </tr>
-        <tr>
-            <td><kbd>Shift</kbd>+<kbd>PageUp</kbd></td>
-            <td>extends the selection up by one page of visible rows</td>
-        </tr>
-        <tr>
-            <td><kbd>Shift</kbd>+<kbd>PageDown</kbd></td>
-            <td>extends the selection down by one page of visible rows</td>
-        </tr>
     </tbody>
 </table>
 
@@ -3363,15 +3331,7 @@ The list of the shortcut keys for editing is given below:
     <tbody>
         <tr>
             <td><kbd>Enter</kbd></td>
-            <td>opens the editor in the selected cell. If the editor is currently opened - closes the editor and saves changes. On a boolean (checkbox) cell, toggles the value</td>
-        </tr>
-        <tr>
-            <td><kbd>F2</kbd></td>
-            <td>opens the editor in the selected cell (non-boolean cells) - an alternative to <kbd>Enter</kbd></td>
-        </tr>
-        <tr>
-            <td><kbd>Space</kbd></td>
-            <td>toggles a boolean (checkbox) cell without opening a text editor</td>
+            <td>opens the editor in the selected cell. If the editor is currently opened - closes the editor and saves changes</td>
         </tr>
         <tr>
             <td><kbd>Escape</kbd></td>
@@ -3484,90 +3444,3 @@ The following shortcut key is available when the [`editable` mode](grid/api/grid
         </tr>
     </tbody>
 </table>
-
-### Shortcut keys for the header
-
-The column header is a navigable focus zone. The following shortcut keys are available when the focus is in the header:
-
-<table>
-    <tbody>
-        <tr>
-            <td><kbd>ArrowLeft</kbd> / <kbd>ArrowRight</kbd></td>
-            <td>move between header cells (colspan-aware: the focus skips cells covered by a span and lands on the owning cell)</td>
-        </tr>
-        <tr>
-            <td><kbd>ArrowUp</kbd> / <kbd>ArrowDown</kbd></td>
-            <td>move between header rows in a multi-row header. <kbd>ArrowUp</kbd> from the first row has no effect; <kbd>ArrowDown</kbd> from the last row moves the focus into the body</td>
-        </tr>
-        <tr>
-            <td><kbd>Enter</kbd> / <kbd>Space</kbd></td>
-            <td>sort by the column. On a header cell that contains a filter control, <kbd>Enter</kbd> activates the filter (the inner control receives focus)</td>
-        </tr>
-        <tr>
-            <td><kbd>Shift</kbd>+<kbd>Enter</kbd></td>
-            <td>toggle multi-column sort for the column (requires the [`multiSort`](grid/api/grid_multisort_config.md) property)</td>
-        </tr>
-        <tr>
-            <td><kbd>Tab</kbd> / <kbd>Shift</kbd>+<kbd>Tab</kbd></td>
-            <td>move within the header with row wrapping; <kbd>Tab</kbd> past the last header cell moves the focus into the body, <kbd>Shift</kbd>+<kbd>Tab</kbd> before the first header cell exits the grid</td>
-        </tr>
-        <tr>
-            <td><kbd>Escape</kbd></td>
-            <td>deactivate an active filter control and return the focus to its header cell; a second <kbd>Escape</kbd> returns the focus to the body</td>
-        </tr>
-    </tbody>
-</table>
-
-### Shortcut keys for the footer
-
-The footer is a navigable focus zone, symmetric with the header. The following shortcut keys are available when the focus is in the footer:
-
-<table>
-    <tbody>
-        <tr>
-            <td><kbd>ArrowLeft</kbd> / <kbd>ArrowRight</kbd></td>
-            <td>move between footer cells (colspan-aware)</td>
-        </tr>
-        <tr>
-            <td><kbd>ArrowUp</kbd> / <kbd>ArrowDown</kbd></td>
-            <td>move between footer rows in a multi-row footer. <kbd>ArrowUp</kbd> from the first row moves the focus into the body; <kbd>ArrowDown</kbd> from the last row has no effect</td>
-        </tr>
-        <tr>
-            <td><kbd>Enter</kbd></td>
-            <td>activate a footer filter control</td>
-        </tr>
-        <tr>
-            <td><kbd>Tab</kbd> / <kbd>Shift</kbd>+<kbd>Tab</kbd></td>
-            <td>move within the footer with row wrapping; <kbd>Shift</kbd>+<kbd>Tab</kbd> before the first footer cell moves the focus into the body, <kbd>Tab</kbd> past the last footer cell exits the grid</td>
-        </tr>
-        <tr>
-            <td><kbd>Escape</kbd></td>
-            <td>deactivate an active filter control and return the focus to its footer cell, or return the focus to the body</td>
-        </tr>
-    </tbody>
-</table>
-
-### Shortcut keys for the TreeGrid
-
-In the TreeGrid mode (`type: "tree"`), the arrow keys operate on the tree column in addition to the [`Ctrl+Enter`](#default-shortcut-keys) expand/collapse toggle:
-
-<table>
-    <tbody>
-        <tr>
-            <td><kbd>ArrowRight</kbd></td>
-            <td>expands a collapsed branch; on an expanded branch with children, moves the focus to the first child row</td>
-        </tr>
-        <tr>
-            <td><kbd>ArrowLeft</kbd></td>
-            <td>collapses an expanded branch; on a leaf or a collapsed branch, moves the focus to the parent row</td>
-        </tr>
-        <tr>
-            <td><kbd>Ctrl</kbd>+<kbd>Enter</kbd></td>
-            <td>toggles expand/collapse of the row</td>
-        </tr>
-    </tbody>
-</table>
-
-:::tip
-For the full picture of the keyboard model together with the WAI-ARIA semantics and the focus model, see the [Grid accessibility](grid/accessibility.md) guide.
-:::

--- a/docs/grid/configuration.md
+++ b/docs/grid/configuration.md
@@ -3159,7 +3159,7 @@ For information on working with the History API, read the [Work with History mod
 
 ## Keyboard navigation
 
-DHTMLX Grid provides the keyboard navigation that will help you manipulate your grid faster. 
+DHTMLX Grid provides the keyboard navigation that will help you manipulate your grid faster. Shortcuts are organized into **zones** - the body, header, and footer - and are resolved by where the focus currently is. Focus enters the grid through hidden focus sentinels and moves between the zones with the <kbd>Arrow</kbd> and <kbd>Tab</kbd> keys. For ARIA semantics, the focus model, and configuration recipes, refer to the following guide: [Grid accessibility](grid/accessibility.md).
 
 ### Default shortcut keys
 
@@ -3168,23 +3168,15 @@ The navigation shortcut keys and keys combinations that Grid enables by default 
 <table>
     <tbody>
         <tr>
-            <td><b>PageUp</b></td>
-            <td>scrolls Grid up to the height of the visible content (without change of the selected cell)</td>
+            <td><kbd>PageUp</kbd></td>
+            <td>moves the selected cell up by one page of visible rows; when no cell is selected, scrolls Grid up to the height of the visible content</td>
         </tr>
         <tr>
-            <td><b>PageDown</b></td>
-            <td>scrolls Grid down to the height of the visible content (without change of the selected cell)</td>
+            <td><kbd>PageDown</kbd></td>
+            <td>moves the selected cell down by one page of visible rows; when no cell is selected, scrolls Grid down to the height of the visible content</td>
         </tr>
         <tr>
-            <td><b>Home</b></td>
-            <td>navigates to the beginning of the Grid content (without change of the selected cell)</td>
-        </tr>
-        <tr>
-            <td><b>End</b></td>
-            <td>navigates to the end of the Grid content (without change of the selected cell)</td>
-        </tr>
-        <tr>
-            <td><b>Ctrl+Enter</b></td>
+            <td><kbd>Ctrl</kbd>+<kbd>Enter</kbd></td>
             <td>expands/collapses the parent item in the TreeGrid mode</td>
         </tr>
     </tbody>
@@ -3226,44 +3218,60 @@ The list of the shortcut keys and their combinations used for moving selection b
 <table>
     <tbody>
         <tr>
-            <td><b>ArrowUp</b></td>
+            <td><kbd>ArrowUp</kbd></td>
             <td>moves selection to the previous vertical cell</td>
         </tr>
         <tr>
-            <td><b>ArrowDown</b></td>
+            <td><kbd>ArrowDown</kbd></td>
             <td>moves selection to the next vertical cell</td>
         </tr>
         <tr>
-            <td><b>ArrowLeft</b></td>
+            <td><kbd>ArrowLeft</kbd></td>
             <td>moves selection to the previous horizontal cell</td>
         </tr>
         <tr>
-            <td><b>ArrowRight</b></td>
+            <td><kbd>ArrowRight</kbd></td>
             <td>moves selection to the next horizontal cell</td>
         </tr>
         <tr>
-            <td><b>Ctrl+ArrowUp</b></td>
+            <td><kbd>Ctrl</kbd>+<kbd>ArrowUp</kbd></td>
             <td>moves selection to the first vertical cell</td>
         </tr>
         <tr>
-            <td><b>Ctrl+ArrowDown</b></td>
+            <td><kbd>Ctrl</kbd>+<kbd>ArrowDown</kbd></td>
             <td>moves selection to the last vertical cell</td>
         </tr>
         <tr>
-            <td><b>Ctrl+ArrowLeft</b></td>
+            <td><kbd>Ctrl</kbd>+<kbd>ArrowLeft</kbd></td>
             <td> moves selection to the first horizontal cell</td>
         </tr>
         <tr>
-            <td><b>Ctrl+ArrowRight</b></td>
+            <td><kbd>Ctrl</kbd>+<kbd>ArrowRight</kbd></td>
             <td> moves selection to the last horizontal cell</td>
         </tr>
         <tr>
-            <td><b>Tab</b></td>
-            <td> moves selection to the next horizontal cell or the first cell of the next row</td>
+            <td><kbd>Home</kbd></td>
+            <td>moves selection to the first cell (column) of the current row</td>
         </tr>
         <tr>
-            <td><b>Shit+Tab</b></td>
-            <td> moves selection to the previous horizontal cell or to the first cell of the previous row</td>
+            <td><kbd>End</kbd></td>
+            <td>moves selection to the last cell (column) of the current row</td>
+        </tr>
+        <tr>
+            <td><kbd>Ctrl</kbd>+<kbd>Home</kbd></td>
+            <td>moves selection to the first cell of the grid</td>
+        </tr>
+        <tr>
+            <td><kbd>Ctrl</kbd>+<kbd>End</kbd></td>
+            <td>moves selection to the last cell of the grid</td>
+        </tr>
+        <tr>
+            <td><kbd>Tab</kbd></td>
+            <td>moves selection to the next horizontal cell or the first cell of the next row; at the end of the grid moves the focus into the footer (when it exists) or out of the grid</td>
+        </tr>
+        <tr>
+            <td><kbd>Shift</kbd>+<kbd>Tab</kbd></td>
+            <td>moves selection to the previous horizontal cell or to the last cell of the previous row; at the beginning of the grid moves the focus into the header or out of the grid</td>
         </tr>
     </tbody>
 </table>
@@ -3273,36 +3281,60 @@ The combinations of the shortcut keys listed below do not work when the `selecti
 <table>
     <tbody>
         <tr>
-            <td><b>Shift+ArrowUp</b></td>
+            <td><kbd>Shift</kbd>+<kbd>ArrowUp</kbd></td>
             <td>moves selection to the previous vertical cell with the change of the selected cells</td>
         </tr>
         <tr>
-            <td><b>Shift+ArrowDown</b></td>
+            <td><kbd>Shift</kbd>+<kbd>ArrowDown</kbd></td>
             <td>moves selection to the next vertical cell with the change of the selected cells</td>
         </tr>
         <tr>
-            <td><b>Shift+ArrowLeft</b></td>
+            <td><kbd>Shift</kbd>+<kbd>ArrowLeft</kbd></td>
             <td>moves selection to the previous horizontal cell with the change of the selected cells</td>
         </tr>
         <tr>
-            <td><b>Shift+ArrowRight</b></td>
+            <td><kbd>Shift</kbd>+<kbd>ArrowRight</kbd></td>
             <td>moves selection to the next horizontal cell with the change of the selected cells</td>
         </tr>
         <tr>
-            <td><b>Ctrl+Shift+ArrowUp</b></td>
+            <td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>ArrowUp</kbd></td>
             <td>moves selection to the first vertical cell with the change of the selected cells</td>
         </tr>
         <tr>
-            <td><b>Ctrl+Shift+ArrowDown</b></td>
+            <td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>ArrowDown</kbd></td>
             <td>moves selection to the last vertical cell with the change of the selected cells</td>
         </tr>
         <tr>
-            <td><b>Ctrl+Shift+ArrowLeft</b></td>
+            <td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>ArrowLeft</kbd></td>
             <td>moves selection to the first horizontal cell with the change of the selected cells</td>
         </tr>
         <tr>
-            <td><b>Ctrl+Shift+ArrowRight</b></td>
+            <td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>ArrowRight</kbd></td>
             <td>moves selection to the last horizontal cell with the change of the selected cells</td>
+        </tr>
+        <tr>
+            <td><kbd>Shift</kbd>+<kbd>Home</kbd></td>
+            <td>extends the selection to the first cell of the current row</td>
+        </tr>
+        <tr>
+            <td><kbd>Shift</kbd>+<kbd>End</kbd></td>
+            <td>extends the selection to the last cell of the current row</td>
+        </tr>
+        <tr>
+            <td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Home</kbd></td>
+            <td>extends the selection to the first cell of the grid</td>
+        </tr>
+        <tr>
+            <td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>End</kbd></td>
+            <td>extends the selection to the last cell of the grid</td>
+        </tr>
+        <tr>
+            <td><kbd>Shift</kbd>+<kbd>PageUp</kbd></td>
+            <td>extends the selection up by one page of visible rows</td>
+        </tr>
+        <tr>
+            <td><kbd>Shift</kbd>+<kbd>PageDown</kbd></td>
+            <td>extends the selection down by one page of visible rows</td>
         </tr>
     </tbody>
 </table>
@@ -3330,15 +3362,23 @@ The list of the shortcut keys for editing is given below:
 <table>
     <tbody>
         <tr>
-            <td><b>Enter</b></td>
-            <td>opens the editor in the selected cell. If the editor is currently opened - closes the editor and saves changes</td>
+            <td><kbd>Enter</kbd></td>
+            <td>opens the editor in the selected cell. If the editor is currently opened - closes the editor and saves changes. On a boolean (checkbox) cell, toggles the value</td>
         </tr>
         <tr>
-            <td><b>Escape</b></td>
+            <td><kbd>F2</kbd></td>
+            <td>opens the editor in the selected cell (non-boolean cells) - an alternative to <kbd>Enter</kbd></td>
+        </tr>
+        <tr>
+            <td><kbd>Space</kbd></td>
+            <td>toggles a boolean (checkbox) cell without opening a text editor</td>
+        </tr>
+        <tr>
+            <td><kbd>Escape</kbd></td>
             <td>closes the editor of the selected cell without saving</td>
         </tr>
         <tr>
-            <td><b>Delete</b></td>
+            <td><kbd>Delete</kbd></td>
             <td>clears data in the selected cells. Works only with the <a href="../usage_blockselection/#keyboard-navigation">`BlockSelection` module</a> in the "range" mode</td>
         </tr>
     </tbody>
@@ -3357,67 +3397,67 @@ The module supports keyboard navigation for selecting and managing ranges, simil
 <table>
     <tbody>
         <tr>
-            <td><b>ArrowUp</b></td>
+            <td><kbd>ArrowUp</kbd></td>
             <td>resets the selected range and moves the focus to the previous vertical cell, setting the initially selected cell if no selection is active</td>
         </tr>
         <tr>
-            <td><b>ArrowDown</b></td>
+            <td><kbd>ArrowDown</kbd></td>
             <td>resets the selected range and moves the focus to the next vertical cell, setting the initially selected cell if no selection is active</td>
         </tr>
         <tr>
-            <td><b>ArrowLeft</b></td>
+            <td><kbd>ArrowLeft</kbd></td>
             <td>resets the selected range and moves the focus to the previous horizontal cell, setting the initially selected cell if no selection is active</td>
         </tr>
         <tr>
-            <td><b>ArrowRight</b></td>
+            <td><kbd>ArrowRight</kbd></td>
             <td>resets the selected range and moves the focus to the next horizontal cell, setting the initially selected cell if no selection is active</td>
         </tr>
          <tr>
-            <td><b>Shift+ArrowUp</b></td>
+            <td><kbd>Shift</kbd>+<kbd>ArrowUp</kbd></td>
             <td>extends the selected range from the current initial cell to the previous vertical cell</td>
         </tr>
         <tr>
-            <td><b>Shift+ArrowDown</b></td>
+            <td><kbd>Shift</kbd>+<kbd>ArrowDown</kbd></td>
             <td>extends the selected range from the current initial cell to the next vertical cell </td>
         </tr>
         <tr>
-            <td><b>Shift+ArrowLeft</b></td>
+            <td><kbd>Shift</kbd>+<kbd>ArrowLeft</kbd></td>
             <td>extends the selected range from the current initial cell to the previous horizontal cell </td>
         </tr>
         <tr>
-            <td><b>Shift+ArrowRight</b></td>
+            <td><kbd>Shift</kbd>+<kbd>ArrowRight</kbd></td>
             <td>extends the selected range from the current initial cell to the next horizontal cell </td>
         </tr>
         <tr>
-            <td><b>Ctrl+ArrowUp</b></td>
+            <td><kbd>Ctrl</kbd>+<kbd>ArrowUp</kbd></td>
             <td>resets the selected range and moves the focus to the first vertical cell</td>
         </tr>
         <tr>
-            <td><b>Ctrl+ArrowDown</b></td>
+            <td><kbd>Ctrl</kbd>+<kbd>ArrowDown</kbd></td>
             <td>resets the selected range and moves the focus to the last vertical cell</td>
         </tr>
         <tr>
-            <td><b>Ctrl+ArrowLeft</b></td>
+            <td><kbd>Ctrl</kbd>+<kbd>ArrowLeft</kbd></td>
             <td>resets the selected range and moves the focus to the first horizontal cell</td>
         </tr>
         <tr>
-            <td><b>Ctrl+ArrowRight</b></td>
+            <td><kbd>Ctrl</kbd>+<kbd>ArrowRight</kbd></td>
             <td>resets the selected range and moves the focus to the last horizontal cell</td>
         </tr>
         <tr>
-            <td><b>Ctrl+Shift+ArrowUp</b></td>
+            <td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>ArrowUp</kbd></td>
             <td>extends the selected range to the first vertical cell</td>
         </tr>
         <tr>
-            <td><b>Ctrl+Shift+ArrowDown</b></td>
+            <td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>ArrowDown</kbd></td>
             <td>extends the selected range to the last vertical cell</td>
         </tr>
         <tr>
-            <td><b>Ctrl+Shift+ArrowLeft</b></td>
+            <td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>ArrowLeft</kbd></td>
             <td> extends the selected range to the first horizontal cell</td>
         </tr>
         <tr>
-            <td><b>Ctrl+Shift+ArrowRight</b></td>
+            <td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>ArrowRight</kbd></td>
             <td> extends the selected range to the last horizontal cell</td>
         </tr>
     </tbody>
@@ -3428,7 +3468,7 @@ The following shortcut key and mouse combination is available:
 <table>
     <tbody>
         <tr>
-            <td><b>Shift + click</b></td>
+            <td><kbd>Shift</kbd> + click</td>
             <td>sets the end cell of the range, extending the selection from the current initial cell</td>
         </tr>
     </tbody>
@@ -3439,8 +3479,95 @@ The following shortcut key is available when the [`editable` mode](grid/api/grid
  <table>
     <tbody>
         <tr>
-            <td><b>Delete</b></td>
+            <td><kbd>Delete</kbd></td>
             <td>allows clearing the selected cells</td>
         </tr>
     </tbody>
 </table>
+
+### Shortcut keys for the header
+
+The column header is a navigable focus zone. The following shortcut keys are available when the focus is in the header:
+
+<table>
+    <tbody>
+        <tr>
+            <td><kbd>ArrowLeft</kbd> / <kbd>ArrowRight</kbd></td>
+            <td>move between header cells (colspan-aware: the focus skips cells covered by a span and lands on the owning cell)</td>
+        </tr>
+        <tr>
+            <td><kbd>ArrowUp</kbd> / <kbd>ArrowDown</kbd></td>
+            <td>move between header rows in a multi-row header. <kbd>ArrowUp</kbd> from the first row has no effect; <kbd>ArrowDown</kbd> from the last row moves the focus into the body</td>
+        </tr>
+        <tr>
+            <td><kbd>Enter</kbd> / <kbd>Space</kbd></td>
+            <td>sort by the column. On a header cell that contains a filter control, <kbd>Enter</kbd> activates the filter (the inner control receives focus)</td>
+        </tr>
+        <tr>
+            <td><kbd>Shift</kbd>+<kbd>Enter</kbd></td>
+            <td>toggle multi-column sort for the column (requires the [`multiSort`](grid/api/grid_multisort_config.md) property)</td>
+        </tr>
+        <tr>
+            <td><kbd>Tab</kbd> / <kbd>Shift</kbd>+<kbd>Tab</kbd></td>
+            <td>move within the header with row wrapping; <kbd>Tab</kbd> past the last header cell moves the focus into the body, <kbd>Shift</kbd>+<kbd>Tab</kbd> before the first header cell exits the grid</td>
+        </tr>
+        <tr>
+            <td><kbd>Escape</kbd></td>
+            <td>deactivate an active filter control and return the focus to its header cell; a second <kbd>Escape</kbd> returns the focus to the body</td>
+        </tr>
+    </tbody>
+</table>
+
+### Shortcut keys for the footer
+
+The footer is a navigable focus zone, symmetric with the header. The following shortcut keys are available when the focus is in the footer:
+
+<table>
+    <tbody>
+        <tr>
+            <td><kbd>ArrowLeft</kbd> / <kbd>ArrowRight</kbd></td>
+            <td>move between footer cells (colspan-aware)</td>
+        </tr>
+        <tr>
+            <td><kbd>ArrowUp</kbd> / <kbd>ArrowDown</kbd></td>
+            <td>move between footer rows in a multi-row footer. <kbd>ArrowUp</kbd> from the first row moves the focus into the body; <kbd>ArrowDown</kbd> from the last row has no effect</td>
+        </tr>
+        <tr>
+            <td><kbd>Enter</kbd></td>
+            <td>activate a footer filter control</td>
+        </tr>
+        <tr>
+            <td><kbd>Tab</kbd> / <kbd>Shift</kbd>+<kbd>Tab</kbd></td>
+            <td>move within the footer with row wrapping; <kbd>Shift</kbd>+<kbd>Tab</kbd> before the first footer cell moves the focus into the body, <kbd>Tab</kbd> past the last footer cell exits the grid</td>
+        </tr>
+        <tr>
+            <td><kbd>Escape</kbd></td>
+            <td>deactivate an active filter control and return the focus to its footer cell, or return the focus to the body</td>
+        </tr>
+    </tbody>
+</table>
+
+### Shortcut keys for the TreeGrid
+
+In the TreeGrid mode (`type: "tree"`), the arrow keys operate on the tree column in addition to the [`Ctrl+Enter`](#default-shortcut-keys) expand/collapse toggle:
+
+<table>
+    <tbody>
+        <tr>
+            <td><kbd>ArrowRight</kbd></td>
+            <td>expands a collapsed branch; on an expanded branch with children, moves the focus to the first child row</td>
+        </tr>
+        <tr>
+            <td><kbd>ArrowLeft</kbd></td>
+            <td>collapses an expanded branch; on a leaf or a collapsed branch, moves the focus to the parent row</td>
+        </tr>
+        <tr>
+            <td><kbd>Ctrl</kbd>+<kbd>Enter</kbd></td>
+            <td>toggles expand/collapse of the row</td>
+        </tr>
+    </tbody>
+</table>
+
+:::tip
+For the full picture of the keyboard model together with the WAI-ARIA semantics and the focus model, see the [Grid accessibility](grid/accessibility.md) guide.
+:::

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -10,20 +10,6 @@ description: You can explore how to migrate to newer versions in the documentati
 If you are using an outdated version of DHTMLX Suite 5 and require the documentation for it, please [contact us](https://dhtmlx.com/docs/contact.shtml), and we will send it to you.
 :::
 
-9.3.3 -> 9.3.5
------------
-
-### Grid
-
-#### Keyboard navigation behaviour of Home/End and Page Up/Page Down
-
-Since v9.3.5, <kbd>Home</kbd>, <kbd>End</kbd>, <kbd>Page Up</kbd>, and <kbd>Page Down</kbd> keys move the **selected (active) cell** instead of only scrolling the viewport (as part of the new [accessibility and keyboard navigation](grid/accessibility.md) model):
-
-- <kbd>Home</kbd> / <kbd>End</kbd> move the selected cell to the first / last column of the current row (previously they scrolled to the beginning / end of the grid content without changing the selected cell).
-- <kbd>Page Up</kbd> / <kbd>Page Down</kbd> move the selected cell up / down by one page of visible rows (previously they only scrolled the grid by the height of the visible content).
-
-The previous behaviour - scrolling the viewport without changing the active cell - is preserved as a fallback when **no cell is selected**. If you relied on these keys for viewport scrolling while a cell was selected, review the [Keyboard navigation](grid/configuration.md#keyboard-navigation) article for the updated shortcut set.
-
 9.1 -> 9.2
 -----------
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -10,6 +10,20 @@ description: You can explore how to migrate to newer versions in the documentati
 If you are using an outdated version of DHTMLX Suite 5 and require the documentation for it, please [contact us](https://dhtmlx.com/docs/contact.shtml), and we will send it to you.
 :::
 
+9.3.3 -> 9.3.5
+-----------
+
+### Grid
+
+#### Keyboard navigation behaviour of Home/End and Page Up/Page Down
+
+Since v9.3.5, <kbd>Home</kbd>, <kbd>End</kbd>, <kbd>Page Up</kbd>, and <kbd>Page Down</kbd> keys move the **selected (active) cell** instead of only scrolling the viewport (as part of the new [accessibility and keyboard navigation](grid/accessibility.md) model):
+
+- <kbd>Home</kbd> / <kbd>End</kbd> move the selected cell to the first / last column of the current row (previously they scrolled to the beginning / end of the grid content without changing the selected cell).
+- <kbd>Page Up</kbd> / <kbd>Page Down</kbd> move the selected cell up / down by one page of visible rows (previously they only scrolled the grid by the height of the visible content).
+
+The previous behaviour - scrolling the viewport without changing the active cell - is preserved as a fallback when **no cell is selected**. If you relied on these keys for viewport scrolling while a cell was selected, review the [Keyboard navigation](grid/configuration.md#keyboard-navigation) article for the updated shortcut set.
+
 9.1 -> 9.2
 -----------
 
@@ -584,7 +598,7 @@ form.getItem("button_id").setValue("button_value");
 
 ### Confirm message box
 
-10) Before v7.0, the *Space* and *Enter* key were used to confirm the Reject button. Starting with v7.0, the keys confirm the Apply button. The *Esc* key confirms the Reject button.
+10) Before v7.0, the <kbd>Space</kbd> and <kbd>Enter</kbd> key were used to confirm the Reject button. Starting with v7.0, the keys confirm the Apply button. The <kbd>Esc</kbd> key confirms the Reject button.
 
 Also note, that before v7.0, the confirm buttons were displayed in the following order: "Apply" and "Reject". In the version 7.0, the order has been changed to "Reject" and "Apply".
 

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -33,10 +33,6 @@ For additional information, refer to [Grid accessibility](grid/accessibility.md)
 - Tree. Fixed an error when removing items in autoload mode
 - Window. Fixed drag/resize positioning issues on scrolled pages
 
-### Breaking changes
-
-- Grid. The <kbd>Home</kbd>/<kbd>End</kbd> and <kbd>Page Up</kbd>/<kbd>Page Down</kbd> keys now move the selected (active) cell instead of only scrolling the viewport. See the [Migration to Newer Versions](migration.md) guide for additional information.
-
 ## Version 9.3.3 
 
 Released on June 2, 2026

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -8,6 +8,35 @@ description: You can explore what's new in DHTMLX Suite and its release history 
 
 Before updating DHTMLX to the latest version, please check the [Migration to Newer Versions](migration.md) guide to avoid possible breakdowns.
 
+## Version 9.3.5
+
+Released on July 1, 2026
+
+### Updates
+
+- Grid. Full WAI-ARIA accessibility support: implemented proper ARIA roles, states (selection, expansion), and accessible labels for editors and filters to support screen readers (WCAG 2.2 compliance)
+- Grid. Advanced Keyboard Navigation:
+    - Added navigation for Headers, Footers, and Grouping panel
+    - Added support for sorting via keyboard (<kbd>Enter</kbd>/<kbd>Space</kbd>)
+    - Added support for <kbd>PageUp</kbd>/<kbd>PageDown</kbd>, <kbd>Home</kbd>/<kbd>End</kbd>, and <kbd>Ctrl</kbd>+<kbd>Home</kbd>/<kbd>End</kbd> for cell focus movement
+    - Added <kbd>F2</kbd> shortcut to enter edit mode
+- Grid. Added standard keyboard patterns: <kbd>ArrowRight</kbd>/<kbd>ArrowLeft</kbd> for expanding and collapsing rows
+- Grid. Improved performance of rendering and selection state tracking in large datasets
+
+For additional information, refer to [Grid accessibility](grid/accessibility.md) and [Keyboard navigation](grid/configuration.md#keyboard-navigation) guides.
+
+### Fixes
+
+- Grid. Fixed clipboard operations (copy/paste) for frozen columns (`leftSplit`/`rightSplit`)
+- Grid. Fixed focus restoration to the cell after closing an editor
+- Grid. Fixed row highlighting and dropdown behavior in the `bottomSplit` area.
+- Tree. Fixed an error when removing items in autoload mode
+- Window. Fixed drag/resize positioning issues on scrolled pages
+
+### Breaking changes
+
+- Grid. The <kbd>Home</kbd>/<kbd>End</kbd> and <kbd>Page Up</kbd>/<kbd>Page Down</kbd> keys now move the selected (active) cell instead of only scrolling the viewport. See the [Migration to Newer Versions](migration.md) guide for additional information.
+
 ## Version 9.3.3 
 
 Released on June 2, 2026

--- a/sidebars.js
+++ b/sidebars.js
@@ -2988,6 +2988,7 @@ module.exports = {
             "grid/usage_dragpanel",
             "grid/usage_history",
             "grid/customization",
+            "grid/accessibility",
             "grid/events"
           ],
         },


### PR DESCRIPTION
- new Grid accessibility guide (docs/grid/accessibility.md): WAI-ARIA roles/attributes, selection modes, keyboard model, high-contrast themes
- whatsnew 9.3.5 release notes and migration note: Home/End and Page Up/Down now move the active cell instead of only scrolling
- reworked Grid keyboard navigation section in configuration.md; key names wrapped in <kbd> across the accessibility guides
- cross-links to the accessibility guide from the editable, keyNavigation, selection, and type configs; accessibility page added to the sidebar