### PR TITLE
[update] ChatGPT MCP documentation link

### DIFF
--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -159,7 +159,7 @@ Then run `agy` in the terminal.
 ### ChatGPT
 
 :::info
-For more information, consult the [official documentation](https://developers.openai.com/api/docs/guides/tools-connectors-mcp).
+For more information, consult the [official documentation](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt).
 :::
 
 Follow these steps:


### PR DESCRIPTION
- OpenAI moved MCP connector docs to a help-center article
- old developers.openai.com link replaced with the current one