### PR TITLE
[update] grammar and style in Calendar articles

### DIFF
--- a/docs/calendar/configuring.md
+++ b/docs/calendar/configuring.md
@@ -8,9 +8,9 @@ description: You can explore the configuration of Calendar in the documentation 
 
 ## Calendar modes
 
-There are several modes of displaying Calendar, which are set via the [](calendar/api/calendar_mode_config.md) property:
+Calendar supports several display modes. Set the [](calendar/api/calendar_mode_config.md) property to choose one:
 
-- **"calendar"** - the default mode. The current date (year and month) is shown in the calendar
+- `"calendar"` - the default mode. The calendar shows the current date (year and month).
 
 ~~~js
 const calendar = new dhx.Calendar("calendar_container");
@@ -18,7 +18,7 @@ const calendar = new dhx.Calendar("calendar_container");
 
 ![Calendar in default day mode showing the month grid for July 2019 in DHTMLX Suite](/img/calendar/calendar_mode.png)
 
-- **"month"** - only months of the current year are shown in the calendar 
+- `"month"` - the calendar shows only months of the current year. 
 
 ~~~js
 const calendar = new dhx.Calendar("calendar_container", {
@@ -28,7 +28,7 @@ const calendar = new dhx.Calendar("calendar_container", {
 
 ![Calendar in month mode listing the twelve months of 2019 in DHTMLX Suite](/img/calendar/month_mode.png)
 
-- **"year"** - only years are shown, including the current one
+- `"year"` - the calendar shows only years, including the current one.
 
 ~~~js
 const calendar = new dhx.Calendar("calendar_container", {
@@ -40,12 +40,12 @@ const calendar = new dhx.Calendar("calendar_container", {
 
 **Related sample**: [Calendar. Calendar modes](https://snippet.dhtmlx.com/n9q0tc0q)
 
-You can also show the calendar in one of the modes using the [](calendar/api/calendar_showdate_method.md) method.
+Call the [](calendar/api/calendar_showdate_method.md) method to show the calendar in one of the modes.
 
 ## Date format
 
-There is a possibility to specify the format of dates in the calendar via the [](calendar/api/calendar_dateformat_config.md) property. The default format is "%d/%m/%y". 
-The full list of available characters used to make formats is provided in the [API reference](calendar/api/calendar_dateformat_config.md).
+Set the [](calendar/api/calendar_dateformat_config.md) property to specify the date format in the calendar. The default format is "%d/%m/%y". 
+The [API reference](calendar/api/calendar_dateformat_config.md) lists all characters available for formats.
 
 ~~~js
 const calendar = new dhx.Calendar("calendar_container", {
@@ -61,8 +61,8 @@ const calendar = new dhx.Calendar("calendar_container", {
 
 **Related sample**: [Calendar. Marked and disabled dates](https://snippet.dhtmlx.com/ic5oeiga)
 
-To disable certain dates, use the [](calendar/api/calendar_disableddates_config.md) setting. The value of the property must be a function that takes a *date* as a parameter and returns a *boolean* value.
-The dates, for which the function returns *true*, are dimmed in the calendar.
+The [](calendar/api/calendar_disableddates_config.md) setting accepts a function that takes a `date` as a parameter and returns a `boolean` value.
+The calendar dims every date for which the function returns `true`.
 
 ~~~js
 const calendar = new dhx.Calendar("calendar_container", {
@@ -88,7 +88,7 @@ const calendar = new dhx.Calendar("calendar_container", {
 
 **Related sample**: [Calendar. The days of this month only](https://snippet.dhtmlx.com/4wi5hbtr)
 
-A default calendar shows both the days of the current month and several days of the previous and next months. You can choose the mode of displaying just the current month by setting the value of the [](calendar/api/calendar_thismonthonly_config.md) configuration property to *true*:
+A default calendar shows both the days of the current month and several days of the previous and next months. Set the [](calendar/api/calendar_thismonthonly_config.md) configuration property to `true` to show only the current month:
 
 ~~~js
 const calendar = new dhx.Calendar("calendar_container", {
@@ -102,7 +102,7 @@ const calendar = new dhx.Calendar("calendar_container", {
 
 **Related sample**: [Calendar. Marked and disabled dates](https://snippet.dhtmlx.com/ic5oeiga)
 
-You can highlight certain dates in the calendar. Set the [](calendar/api/calendar_mark_config.md) property for that. The value of the property must be a function that takes a *date* as a parameter and returns a *string* with the name of a CSS class for marked dates or an empty string for other dates.
+Set the [](calendar/api/calendar_mark_config.md) property to highlight dates in the calendar. The property takes a function that receives a `date` and returns a `string`. Return the name of a CSS class to mark the date, or an empty string to leave it unmarked.
 
 ~~~js
 const calendar = new dhx.Calendar("calendar_container", {
@@ -115,7 +115,7 @@ const calendar = new dhx.Calendar("calendar_container", {
 });
 ~~~
 
-Where "highlight-date" is a CSS class like this:
+Where `highlight-date` is a CSS class like this:
 
 ~~~html
 <style>
@@ -127,7 +127,7 @@ Where "highlight-date" is a CSS class like this:
 
 ## Initial calendar date
 
-By default, a calendar shows a month with the current date. If for some reason you want to open some other date, set the [](calendar/api/calendar_date_config.md) property. It accepts a Date object as a value. It is either the same as [](calendar/api/calendar_value_config.md) (by default), or shows the current date if **value** is not specified.
+The default view is the month that contains the current date. To open a different date, set the [](calendar/api/calendar_date_config.md) property. The property accepts a Date object as a value. Its default equals [](calendar/api/calendar_value_config.md); if you do not specify `value`, the calendar shows the current date.
 
 ~~~js
 const calendar = new dhx.Calendar("calendar_container", {
@@ -139,12 +139,12 @@ const calendar = new dhx.Calendar("calendar_container", {
 
 ## Initially selected date
 
-If you want to create a calendar with an initially selected date, set the [](calendar/api/calendar_value_config.md) property in the configuration object. The property can accept a value in several formats:
+To create a calendar with an initially selected date, set the [](calendar/api/calendar_value_config.md) property in the configuration object. The property can accept a value in several formats:
 
-- as a Date object
-- as a string
-- as an array of Date values for the range mode
-- as an array of string values for the range mode
+- A Date object
+- A string
+- An array of Date values for the range mode
+- An array of string values for the range mode
 
 ~~~js
 // selects a date
@@ -182,10 +182,10 @@ const calendar = new dhx.Calendar("calendar_container", {
 
 **Related sample**: [Calendar. Value initialization](https://snippet.dhtmlx.com/epjjww3l)
 
-The specified date will be highlighted with a round blue marker in the calendar. By default, no date is selected initially.
+The calendar highlights the specified date with a round blue marker. No date is selected initially.
 
 :::note
-Please note that the format of date in the Calendar is defined by the dateFormat option. So, check that you've set the format of date you want to use in the calendar both in the [](calendar/api/calendar_value_config.md) and in the [](calendar/api/calendar_dateformat_config.md) property. Otherwise, the default format ("%d/%m/%y") will be used.
+The `dateFormat` option defines the date format in the Calendar. Check that you set the same date format both in the [](calendar/api/calendar_value_config.md) and in the [](calendar/api/calendar_dateformat_config.md) property. Otherwise, the calendar uses the default format ("%d/%m/%y").
 :::
 
 ## Numbers of weeks
@@ -194,7 +194,7 @@ Please note that the format of date in the Calendar is defined by the dateFormat
 
 **Related sample**: [Calendar. Numbers of weeks](https://snippet.dhtmlx.com/9692gk6n)
 
-If you want to display the numbers of weeks in the calendar, enable the [](calendar/api/calendar_weeknumbers_config.md) property. By default, the numbers are not shown as the property is set to *false*.
+To display week numbers in the calendar, enable the [](calendar/api/calendar_weeknumbers_config.md) property. The property defaults to `false`.
 
 ~~~js
 const calendar = new dhx.Calendar("calendar_container", {
@@ -208,7 +208,7 @@ const calendar = new dhx.Calendar("calendar_container", {
 
 **Related sample**: [Calendar. Range](https://snippet.dhtmlx.com/2mrj53h0)
 
-You have a possibility to create a calendar in the range mode that allows you to select a range of dates in the calendar. To do this, you need to use the [range:true](calendar/api/calendar_range_config.md) option in the calendar configuration object and define an array with the start and end dates of the range.
+You can create a calendar in the range mode that allows you to select a range of dates. Use the [range:true](calendar/api/calendar_range_config.md) option in the calendar configuration object and define an array with the start and end dates of the range.
 
 ~~~js
 const calendar = new dhx.Calendar("calendar_container", {
@@ -219,7 +219,7 @@ const calendar = new dhx.Calendar("calendar_container", {
 ~~~
 
 :::note
-The **value** option should have the array type and contain a pair of values (either Date values or string values) for both dates.
+The `value` option must be an array that contains a pair of values (either Date values or string values) for both dates.
 :::
 
 ## Start of the week
@@ -228,7 +228,7 @@ The **value** option should have the array type and contain a pair of values (ei
 
 **Related sample**: [Calendar. Week start](https://snippet.dhtmlx.com/kaxmurh9)
 
-By default, the first day of the week is Sunday, as the **weekStart:"sunday"** configuration option is used. It is also possible to set Monday as the start of the week, by applying "monday" as a value of the [](calendar/api/calendar_weekstart_config.md) setting:
+The default first day of the week is Sunday (`weekStart:"sunday"`). You can also set Monday as the first day of the week. Apply `"monday"` as the value of the [](calendar/api/calendar_weekstart_config.md) setting:
 
 ~~~js
 const calendar = new dhx.Calendar("calendar_container", {
@@ -238,8 +238,8 @@ const calendar = new dhx.Calendar("calendar_container", {
 
 ## Timepicker
 
-You can add a timepicker into a calendar by enabling the [](calendar/api/calendar_timepicker_config.md) property. By default, a timepicker uses the 24-hour format.
-You can change it to the 12-hour format via the [](calendar/api/calendar_timeformat_config.md) property. It accepts either 12 or 24 value to select the desired time format.
+Enable the [](calendar/api/calendar_timepicker_config.md) property to add a timepicker to a calendar. The default timepicker format is 24-hour.
+Set the [](calendar/api/calendar_timeformat_config.md) property to switch to the 12-hour format. The property accepts either 12 or 24 to select the time format.
 
 ~~~js
 const calendar = new dhx.Calendar("calendar_container", {
@@ -260,7 +260,7 @@ const calendar = new dhx.Calendar("calendar_container", {
 
 **Related sample**: [Calendar. Calendar width](https://snippet.dhtmlx.com/azm0u5ns)
 
-You can set the desired width of a calendar using the [](calendar/api/calendar_width_config.md) configuration property. The default width of Calendar is 250px.
+Set the [](calendar/api/calendar_width_config.md) configuration property to change the calendar width. The default Calendar width is 250px.
 
 ~~~js
 const calendar = new dhx.Calendar("calendar_container", {

--- a/docs/calendar/customization.md
+++ b/docs/calendar/customization.md
@@ -8,15 +8,15 @@ description: You can explore the customization of Calendar in the documentation 
 
 ## Styling Calendar
 
-There is a possibility to make changes in the look and feel of a calendar. For example, change its background color:
+You can change the look and feel of a calendar. For example, change its background color:
 
 ![Calendar month view styled with a custom teal primary color in DHTMLX Suite](/img/calendar/styled_calendar.png)
 
 **Related sample**: [Calendar. Styling (custom CSS)](https://snippet.dhtmlx.com/2045cbe1)
 
-For this you need to take the following steps:
+Follow these steps:
 
-- add a new CSS class(es) with desired settings in the &lt;style&gt; section of your HTML page or in your file with styles (don't forget to include your file on the page in this case)
+- Add one or more CSS classes in the `<style>` section of your HTML page or in a separate stylesheet linked on the page:
 
 ~~~html
 <style>
@@ -30,7 +30,7 @@ For this you need to take the following steps:
 </style>
 ~~~
 
-- specify the name of the created CSS class (or names of classes separated by spaces) as the value of the [](calendar/api/calendar_css_config.md) property in the Calendar configuration:
+- Assign the class name (or several names separated by spaces) to the [](calendar/api/calendar_css_config.md) property:
 
 ~~~js
 const calendar = new dhx.Calendar("calendar_container", {
@@ -60,7 +60,7 @@ For example:
 
 **Related sample**: [Calendar. Custom styles for selected date](https://snippet.dhtmlx.com/9u0ix3na)
 
-You can apply custom styling to dates selected in a calender as well as to [date ranges](calendar/operating_calendar.md#linking-two-calendars). There are system styles you need to change for this purpose:
+You can style selected dates and [date ranges](calendar/operating_calendar.md#linking-two-calendars) with your own CSS. Override these system styles:
 
 ~~~html
 <style>

--- a/docs/calendar/datepicker.md
+++ b/docs/calendar/datepicker.md
@@ -6,32 +6,32 @@ description: You can explore the DatePicker of Calendar in the documentation of 
 
 # DatePicker
 
-You can use DHTMLX Calendar as a date picker by putting it inside a popup. 
+Put DHTMLX Calendar inside a popup to create a date picker. 
 
 ![Calendar used as a date picker popup attached to a date input field in DHTMLX Suite](/img/calendar/date_picker.png)
 
-First, you should create a popup and then attach a calendar into it. Follow the steps below:
+Follow the steps below:
 
-1\. Create an input to enter a date into and give it the id "date-input":
+1\. Create an input field for the date and give it the id `date-input`:
 
 ~~~html
 <input type="text" id="date-input" style="width: 200px;" readonly/>
 ~~~
 
-2\. Use corresponding object constructors to create a calendar and a popup objects. Note that in this case *null* is used instead of container for Calendar:
+2\. Use the `Calendar` and `Popup` constructors to create the two objects. Note that `Calendar` takes `null` instead of a container:
 
 ~~~js
 const calendar = new dhx.Calendar(null, {dateFormat: "%d/%m/%y"});
 const popup = new dhx.Popup();
 ~~~
 
-3\. Attach the calendar to the popup using the [](popup/api/popup_attach_method.md) method of Popup:
+3\. Call the [](popup/api/popup_attach_method.md) method of `Popup` to attach the calendar:
 
 ~~~js
 popup.attach(calendar);
 ~~~
 
-4\. Use the [](popup/api/popup_show_method.md) method of Popup inside a click handler to define that a popup with calendar will open on click in the "date-input" input:
+4\. Add a click handler to the `date-input` field. Inside the handler, call the [](popup/api/popup_show_method.md) method of `Popup` to open the popup:
 
 ~~~js
 const dateInput = document.getElementById("date-input");
@@ -40,7 +40,7 @@ dateInput.addEventListener("click", function() {
 });
 ~~~
 
-5\. Define the logic of closing the popup with calendar using the [](popup/api/popup_hide_method.md) method of Popup. For example, on selecting a new date in the calendar:
+5\. Close the popup with the [](popup/api/popup_hide_method.md) method of `Popup`. For example, close it when the user selects a new date:
 
 ~~~js
 calendar.events.on("change", function() {

--- a/docs/calendar/features.md
+++ b/docs/calendar/features.md
@@ -6,11 +6,11 @@ description: You can explore the features of Calendar in the documentation of th
 
 # Features
 
-This page contains structured information that will help you to start working with DHTMLX Calendar and go into deep dive on its functionality.
+This page describes how to start with DHTMLX Calendar and explore its functionality in depth.
 
 ## How to start with DHTMLX Calendar
 
-In this section you can find out the ways of Calendar initialization and localization, and learn how to integrate Calendar into your applications.
+Learn how to initialize and localize Calendar, and how to integrate it into your applications.
 
 ### Initialization and localization
 
@@ -25,23 +25,21 @@ In this section you can find out the ways of Calendar initialization and localiz
 
 | Topic                                                   | Description                                                                                                                                  |
 | :------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Backend integration](integration/suite_and_backend.md) | Learn how to connect DHTMLX Suite to a backend  ([Demo](https://github.com/DHTMLX/nodejs-suite-demo))                                        |
-| [Optimus](/optimus_guides/)                            | Learn how to use DHTMLX Optimus framework for creating  DHTMLX-based app <br>(recommended framework for creating apps with Suite components) |
+| [Backend integration](integration/suite_and_backend.md) | Learn how to connect DHTMLX Suite to a backend ([Demo](https://github.com/DHTMLX/nodejs-suite-demo))                                        |
+| [Optimus](/optimus_guides/)                            | Learn how to use the DHTMLX Optimus framework to build a DHTMLX-based app <br>(the recommended framework for apps with Suite components) |
 | [React integration](integration/suite_and_react.md)     | Learn how to use DHTMLX Calendar with React ([Demo](https://github.com/DHTMLX/react-suite-demo))                                                |
 | [Angular integration](integration/suite_and_angular.md) | Learn how to use DHTMLX Calendar with Angular ([Demo](https://github.com/DHTMLX/angular-suite-demo))                                         |
 | [Vue integration](integration/suite_and_vue.md)         | Learn how to use DHTMLX Calendar with Vue.js ([Demo](https://github.com/DHTMLX/vue-suite-demo))                                              |
 
 ## How to configure Calendar
 
-In this section you can discover how to configure Calendar.
-
 | Topic                                                                          | Description                                                                                                                                 |
 | :----------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------ |
-| [Calendar modes](calendar/configuring.md#calendar-modes)                               | Learn how initialize Calendar in different modes (calendar, month, year) ([Example](https://snippet.dhtmlx.com/n9q0tc0q))                   |
+| [Calendar modes](calendar/configuring.md#calendar-modes)                               | Learn how to initialize Calendar in different modes (calendar, month, year) ([Example](https://snippet.dhtmlx.com/n9q0tc0q))                   |
 | [Showing tooltips](calendar/operating_calendar.md#showing-tooltips)                    | Learn how to show tooltips in Calendar ([Example 1](https://snippet.dhtmlx.com/t4jy4wrr), [Example 2](https://snippet.dhtmlx.com/jwx0barf)) |
 | [Start of the week](calendar/configuring.md#start-of-the-week)                         | Learn how to change the starting day of the week ([Example](https://snippet.dhtmlx.com/kaxmurh9))                                           |
-| [Timepicker in Calendar](calendar/configuring.md#timepicker)                           | Learn how to add a timepicker into Calendar ([Example](https://snippet.dhtmlx.com/jkbfb202))                                                |
-| [Showing the week numbers](calendar/configuring.md#numbers-of-weeks)                   | Learn how to show the numbers of weeks ([Example](https://snippet.dhtmlx.com/9692gk6n))                                                     |
+| [Timepicker in Calendar](calendar/configuring.md#timepicker)                           | Learn how to add a timepicker to Calendar ([Example](https://snippet.dhtmlx.com/jkbfb202))                                                |
+| [Showing the week numbers](calendar/configuring.md#numbers-of-weeks)                   | Learn how to show week numbers ([Example](https://snippet.dhtmlx.com/9692gk6n))                                                     |
 | [Displaying only current month](calendar/configuring.md#displaying-only-current-month) | Learn how to display the current month only ([Example](https://snippet.dhtmlx.com/4wi5hbtr))                                                |
 
 ## How to work with dates
@@ -49,9 +47,9 @@ In this section you can discover how to configure Calendar.
 | Topic                                                          | Description                                                                                         |
 | :------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------- |
 | [Initial calendar date](calendar/configuring.md#initial-calendar-date) | Learn how to specify the initial date of Calendar ([Example](https://snippet.dhtmlx.com/fyg6l65t))  |
-| [Highlighted dates](calendar/configuring.md#highlighted-dates)         | Learn how to highlight certain dates in Calendar ([Example](https://snippet.dhtmlx.com/ic5oeiga))   |
-| [Disabled dates](calendar/configuring.md#disabled-dates)               | Learn how to disable certain dates ([Example](https://snippet.dhtmlx.com/ic5oeiga))                 |
-| [Date format](calendar/configuring.md#date-format)                     | Learn how to specify the necessary format of dates ([Example](https://snippet.dhtmlx.com/2co9z3bi)) |
+| [Highlighted dates](calendar/configuring.md#highlighted-dates)         | Learn how to highlight specific dates in Calendar ([Example](https://snippet.dhtmlx.com/ic5oeiga))   |
+| [Disabled dates](calendar/configuring.md#disabled-dates)               | Learn how to disable specific dates ([Example](https://snippet.dhtmlx.com/ic5oeiga))                 |
+| [Date format](calendar/configuring.md#date-format)                     | Learn how to specify the date format ([Example](https://snippet.dhtmlx.com/2co9z3bi)) |
 
 
 ## How to work with selected dates
@@ -67,31 +65,25 @@ In this section you can discover how to configure Calendar.
 | Topic                                                                        | Description                                                                                                 |
 | :--------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------- |
 | [Date ranges in one calendar](calendar/configuring.md#range-mode)                    | Learn how to create a calendar in the range mode ([Example](https://snippet.dhtmlx.com/2mrj53h0))           |
-| [Date ranges in two calendars](calendar/operating_calendar.md#linking-two-calendars) | Learn how to link two calendars for selecting a date range ([Example](https://snippet.dhtmlx.com/dxo54017)) |
+| [Date ranges in two calendars](calendar/operating_calendar.md#linking-two-calendars) | Learn how to link two calendars to select a date range ([Example](https://snippet.dhtmlx.com/dxo54017)) |
 
 ## How to customize Calendar and change its size
 
-In this section you can learn how to change the Calendar width and style.
-
 | Topic                                                              | Description                                                                                          |
 | :----------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
-| [Width of Calendar](calendar/configuring.md#width-of-calendar)             | Learn how to set the necessary width of Calendar ([Example](https://snippet.dhtmlx.com/azm0u5ns))    |
+| [Width of Calendar](calendar/configuring.md#width-of-calendar)             | Learn how to set the Calendar width ([Example](https://snippet.dhtmlx.com/azm0u5ns))    |
 | [Styling (custom CSS)](calendar/customization.md#styling-calendar)         | Learn how to change the look and feel of Calendar ([Example](https://snippet.dhtmlx.com/2045cbe1))   |
 | [Styling selected dates](calendar/customization.md#styling-selected-dates) | Learn how to apply custom styling to selected dates ([Example](https://snippet.dhtmlx.com/9u0ix3na)) |
 | [List of CSS classes](helpers/base_elements.md)                | A set of CSS classes provided by the DHTMLX library                                                  |
 
 ## How to work with Calendar events
 
-This section explains how to work with Calendar events.
-
 | Topic                                       | Description                                                                                               |
 | :------------------------------------------ | :-------------------------------------------------------------------------------------------------------- |
-| [Event basic rules](guides/events_guide.md) | Learn basic rules on how to work with events                                                              |
-| [Event handling](calendar/handling_events.md)       | Learn how to attach, detach, or call the Calendar events ([Example](https://snippet.dhtmlx.com/7kj7fiek)) |
+| [Event basic rules](guides/events_guide.md) | Learn the basic rules for working with events                                                              |
+| [Event handling](calendar/handling_events.md)       | Learn how to attach, detach, or call Calendar events ([Example](https://snippet.dhtmlx.com/7kj7fiek)) |
 
 ## API reference
-
-In this section you can find out corresponding references of Calendar API.
 
 | Topic                                                      | Description                          |
 | :--------------------------------------------------------- | :----------------------------------- |
@@ -101,13 +93,13 @@ In this section you can find out corresponding references of Calendar API.
 
 ## Common functionality
 
-In this section you will learn about common functionality of the library which can be useful while working with Calendar.
+These common features are useful when you work with Calendar.
 
 | Topic                                                         | Description                                                   |
 | :------------------------------------------------------------ | :------------------------------------------------------------ |
 | [Touch support](common_features/touch_support.md)         | Learn how to work with touch support                          |
 | [TypeScript support](common_features/using_typescript.md) | Learn how to work with TypeScript                             |
-| [AwaitRedraw](helpers/await_redraw.md)                    | Learn how to perform the code after the component’s rendering |
+| [AwaitRedraw](helpers/await_redraw.md)                    | Learn how to run code after the component renders |
 
 ## Any questions left?
 

--- a/docs/calendar/handling_events.md
+++ b/docs/calendar/handling_events.md
@@ -6,9 +6,9 @@ description: You can explore the event handling of Calendar in the documentation
 
 # Event handling
 
-## Attaching event listeners
+## Attach event listeners
 
-You can attach event listeners with the **calendar.events.on()** method of the *events* module:
+Use the `calendar.events.on()` method of the `events` module to attach event listeners:
 
 ~~~js
 calendar.events.on("change",function(date, oldDate, byClick){
@@ -17,7 +17,7 @@ calendar.events.on("change",function(date, oldDate, byClick){
 });
 ~~~
 
-For example, Calendar can be attached to an input that will display the date selected in Calendar:
+For example, you can attach Calendar to an input that displays the selected date:
 
 ~~~html
 <input type="text" id="date" />
@@ -31,15 +31,15 @@ calendar.events.on("change",(date)=>{
 });
 ~~~
 
-Several handlers can be attached to one event, and all of them will be executed.
+You can attach several handlers to one event. Calendar executes all of them.
 
-{{note The names of events are case-insensitive.}}
+{{note Event names are case-insensitive.}}
 
 **Related sample**: [Calendar. Events](https://snippet.dhtmlx.com/7kj7fiek)
 
-## Detaching event listeners
+## Detach event listeners
 
-To detach an event listener, use **calendar.events.detach()**:
+Use the `calendar.events.detach()` method to detach an event listener:
 
 ~~~js
 calendar.events.on("change",function(date, oldDate, byClick){
@@ -49,15 +49,15 @@ calendar.events.on("change",function(date, oldDate, byClick){
 calendar.events.detach("change");
 ~~~
 
-## Calling events
+## Call events
 
-To call an event, use **calendar.events.fire()**:
+Use the `calendar.events.fire()` method to call an event:
 
 ~~~js
 calendar.events.fire("name",args);
 // where args is an array of arguments
 ~~~
 
-## The list of events
+## Event list
 
-You can find the full list of events in the [Calendar API](calendar/api/api_overview.md#events).
+You can find the full event list in the [Calendar API](calendar/api/api_overview.md#events).

--- a/docs/calendar/handling_events.md
+++ b/docs/calendar/handling_events.md
@@ -31,7 +31,7 @@ calendar.events.on("change",(date)=>{
 });
 ~~~
 
-You can attach several handlers to one event. Calendar executes all of them.
+You can attach several handlers to one event. Calendar executes all handlers.
 
 {{note Event names are case-insensitive.}}
 
@@ -49,7 +49,7 @@ calendar.events.on("change",function(date, oldDate, byClick){
 calendar.events.detach("change");
 ~~~
 
-## Call events
+## Trigger events
 
 Call `calendar.events.fire()` to trigger an event manually:
 

--- a/docs/calendar/handling_events.md
+++ b/docs/calendar/handling_events.md
@@ -8,7 +8,7 @@ description: You can explore the event handling of Calendar in the documentation
 
 ## Attach event listeners
 
-Use the `calendar.events.on()` method of the `events` module to attach event listeners:
+Use the `calendar.events.on()` method to attach event listeners:
 
 ~~~js
 calendar.events.on("change",function(date, oldDate, byClick){
@@ -39,7 +39,7 @@ You can attach several handlers to one event. Calendar executes all of them.
 
 ## Detach event listeners
 
-Use the `calendar.events.detach()` method to detach an event listener:
+The `calendar.events.detach()` method removes an event listener:
 
 ~~~js
 calendar.events.on("change",function(date, oldDate, byClick){
@@ -51,7 +51,7 @@ calendar.events.detach("change");
 
 ## Call events
 
-Use the `calendar.events.fire()` method to call an event:
+Call `calendar.events.fire()` to trigger an event manually:
 
 ~~~js
 calendar.events.fire("name",args);
@@ -60,4 +60,4 @@ calendar.events.fire("name",args);
 
 ## Event list
 
-You can find the full event list in the [Calendar API](calendar/api/api_overview.md#events).
+For the full event list, see the [Calendar API](calendar/api/api_overview.md#events).

--- a/docs/calendar/how_to_start.md
+++ b/docs/calendar/how_to_start.md
@@ -13,13 +13,13 @@ Download the DHTMLX Calendar package:
 - [as a part of the DHTMLX Suite library](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
 :::
 
-There are two ways of initializing DHTMLX Calendar: inside a container or inside a popup. Both ways are described below in detail.
+You can initialize DHTMLX Calendar in two ways: inside a container or inside a popup.
 
 To use DHTMLX Calendar in your application, you need to take the following simple steps:
 
 - [Include source files](#include-source-files)
 - [Initialize Calendar](#initialize-calendar) with the object constructor
-- [Select initial date (optional)](#select-initial-date-optional)
+- [Select an initial date (optional)](#select-an-initial-date-optional)
 
 ~~~html
 <!DOCTYPE html>
@@ -41,15 +41,15 @@ To use DHTMLX Calendar in your application, you need to take the following simpl
 
 ## Include source files
 
-Unpack the downloaded package into a folder of your project.
+Unpack the downloaded package into your project folder.
 
-After that, create an HTML file and place full paths to JS and CSS files of the library into the header of the created file.
+After that, create an HTML file and add full paths to the library JS and CSS files in its header.
 
 
 **If you use DHTMLX Calendar standalone**, you need to include JS/CSS files of DHTMLX Calendar:
 
-- *calendar.js*
-- *calendar.css*
+- `calendar.js`
+- `calendar.css`
 
 ~~~html title="index.html"
 <link type="text/css" href="../codebase/calendar.css">
@@ -58,8 +58,8 @@ After that, create an HTML file and place full paths to JS and CSS files of the 
 
 **If you use DHTMLX Calendar as a part of the Suite package**, you need to include JS/CSS files of the DHTMLX Suite library:
 
-- *suite.js*
-- *suite.css*
+- `suite.js`
+- `suite.css`
 
 ~~~html title="index.html"
 <link type="text/css" href="../codebase/suite.css">
@@ -68,11 +68,9 @@ After that, create an HTML file and place full paths to JS and CSS files of the 
 
 ## Initialize Calendar
 
-You can initialize Calendar in a container or in a popup.
-
 ### Initialization in a container
 
-In this case you need to add a container for Calendar and give it an id, for example "calendar_container":
+In this case, you need to add a container for Calendar and give it an id, for example `calendar_container`:
 
 ~~~html title="index.html"
 <div id="calendar_container"></div>
@@ -93,11 +91,11 @@ const calendar = new dhx.Calendar("calendar_container", {
 The constructor takes two parameters: 
 
 - the HTML container for Calendar
-- an object with configuration properties ([see the full list below](#configuration-properties)). If this argument is not passed to the constructor, the settings will be default.
+- an object with configuration properties ([see the full list below](#configuration-properties)). If you do not pass this argument to the constructor, Calendar uses the default settings.
 
 ### Initialization in a popup
 
-This variant presupposes that you create a popup first and then attach a calendar into it, thus creating a date picker.
+To create a date picker, create a popup first and then attach Calendar to it.
 
 <iframe src="https://snippet.dhtmlx.com/mj7jr6ro?mode=js" frameborder="0" class="snippet_iframe" width="100%" height="500"></iframe>
 
@@ -107,9 +105,9 @@ Read the details in the [DatePicker](calendar/datepicker.md) article.
 
 Check the full list of Calendar configuration properties in the [Calendar API overview](calendar/api/api_overview.md#properties) article.
 
-## Select initial date (optional)
+## Select an initial date (optional)
 
-You can specify what date should be selected in the calendar before initialization of the component via the [](calendar/api/calendar_value_config.md) configuration option:
+Use the [](calendar/api/calendar_value_config.md) configuration option to select a date before you initialize the component:
 
 ~~~js
 const calendar = new dhx.Calendar("calendar_container", {
@@ -119,7 +117,7 @@ const calendar = new dhx.Calendar("calendar_container", {
 
 **Related sample**: [Calendar. Date initialization](https://snippet.dhtmlx.com/fyg6l65t)
 
-If you need to select a specific date after initialization of Calendar, use the [](calendar/api/calendar_setvalue_method.md) method:
+If you need to select a specific date after you initialize Calendar, use the [](calendar/api/calendar_setvalue_method.md) method:
 
 ~~~js
 const calendar = new dhx.Calendar("calendar_container", {

--- a/docs/calendar/index.md
+++ b/docs/calendar/index.md
@@ -6,7 +6,7 @@ description: You can have an overview of Calendar in the documentation of the DH
 
 # Calendar overview
 
-DHTMLX Calendar is a component that allows users to view and select dates. You can create calendar in one of 4 modes: days, months, years, or as a timepicker. This component is a great date picker solution for your website or application. Check [online samples for DHTMLX Calendar](https://snippet.dhtmlx.com/jkbfb202?tag=calendar).  
+DHTMLX Calendar is a component that allows users to view and select dates. You can create a calendar in one of 4 modes: days, months, years, or timepicker.
 
 ![Calendar month view for April 2019 with the 16th selected and a timepicker in DHTMLX Suite](/img/calendar/calendar_front.png)
 
@@ -23,12 +23,12 @@ You can check the following page to learn how to build a full-featured DHTMLX Ca
 ## Related resources
 
 - To get just DHTMLX Calendar, download it from [our website](https://dhtmlx.com/docs/products/dhtmlxCalendar/download.shtml)
-- To get the whole JavaScript library of UI components [download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
+- To get the whole JavaScript library of UI components, [download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
 - There are also [online samples for DHTMLX Calendar](https://snippet.dhtmlx.com/jkbfb202?tag=calendar)  
   
 ## Guides
 
-You can read the following articles to find out how to add Calendar on the page and work with it.
+You can read the following articles to find out how to add Calendar to a page and work with it.
 
 - [](calendar/how_to_start.md)
 - [](calendar/configuring.md)

--- a/docs/calendar/localizing_calendar.md
+++ b/docs/calendar/localizing_calendar.md
@@ -6,7 +6,7 @@ description: You can explore the localization of Calendar in the documentation o
 
 # Localization
 
-You can apply different languages to the interface of dhtmlxCalendar. You just need to translate the corresponding strings for Calendar labels and apply a ready locale to the component.
+You can apply different languages to the Calendar interface. Translate the strings for Calendar labels and apply the locale to the component.
 
 ![Calendar localized into German with translated month and day names in DHTMLX Suite](/img/calendar/locale.png)
 
@@ -32,9 +32,9 @@ const en = {
 
 ## Custom locale
 
-To use a different locale, your need to:
+To use a different locale, you need to do the following:
 
-- define necessary language settings: provide full and short names of months, as well as full and short names of days of a week:
+- Define necessary language settings: provide full and short names of months, as well as full and short names of days of the week:
 
 ~~~js
 const de = {
@@ -52,7 +52,7 @@ const de = {
 };
 ~~~
 
-- apply the language settings by calling the **dhx.i18n.setLocale()** method before Calendar initialization:
+- Apply the language settings by calling the `dhx.i18n.setLocale()` method before Calendar initialization:
 
 ~~~js
 dhx.i18n.setLocale("calendar", de);

--- a/docs/calendar/operating_calendar.md
+++ b/docs/calendar/operating_calendar.md
@@ -8,20 +8,20 @@ description: You can explore how to work with Calendar in the documentation of t
 
 ## Changing calendar mode
 
-You can show a particular date in the calendar and/or open Calendar in a certain mode via the [](calendar/api/calendar_showdate_method.md) method. It takes two parameters:
+Use the [](calendar/api/calendar_showdate_method.md) method to show a particular date in the calendar or open Calendar in a specific mode. It takes two parameters:
 
-- **date** - (*Date*) the date that should be shown in the calendar
-- **mode** - (*string*)    optional, the mode in which the calendar will be opened
+- `date` - (`Date`) the date that should be shown in the calendar
+- `mode` - (`string`) optional, the mode in which the calendar will be opened
 
 There are the following calendar modes available:
 
-- **"calendar"** - allows selecting among days of a month (default)
+- `"calendar"` - allows you to select a day of the month (default)
 
 ~~~js
 calendar.showDate(new Date(2020,11,12),"calendar");
 ~~~
 
-- **"month"** - allows selecting a month
+- `"month"` - allows you to select a month
 
 ~~~js
 calendar.showDate(new Date(2020,11,12),"month");
@@ -32,7 +32,7 @@ calendar.showDate(null,"month");
 
 **Related sample**: [Calendar. Showing particular calendar date and mode](https://snippet.dhtmlx.com/nyfzc8cl)
 
-- **"year"** - allows selecting a year
+- `"year"` - allows you to select a year
 
 ~~~js
 calendar.showDate(new Date(2020,11,12),"year");
@@ -41,7 +41,7 @@ calendar.showDate(new Date(2020,11,12),"year");
 calendar.showDate(null,"year");
 ~~~
 
-For example, Calendar can be attached to an input, a click on which will show Calendar in one of the modes:
+For example, you can attach Calendar to an input so that a click on the input shows Calendar in one of the modes:
 
 ~~~html
 <input type="text" onclick="showCalendar()" />
@@ -56,12 +56,12 @@ function showCalendar(){
 
 ## Getting current mode
 
-There is a possibility to get the current mode of displaying Calendar via the [getCurrentMode()](calendar/api/calendar_getcurrentmode_method.md) method. The method returns one of the available calendar modes:
+To get the current Calendar mode, call the [getCurrentMode()](calendar/api/calendar_getcurrentmode_method.md) method. It returns one of the available calendar modes:
 
-- month
-- year
-- calendar
-- timepicker
+- `"month"`
+- `"year"`
+- `"calendar"`
+- `"timepicker"`
 
 ~~~js
 const mode = calendar.getCurrentMode(); // -> "calendar"
@@ -71,7 +71,7 @@ const mode = calendar.getCurrentMode(); // -> "calendar"
 
 ## Getting selected date
 
-To get the selected date, call the [](calendar/api/calendar_getvalue_method.md) method. The method returns selected date either as a string (default) or as a Date object. To get a date as an object, pass the *true* parameter to the method.
+To get the selected date, call the [](calendar/api/calendar_getvalue_method.md) method. The method returns the selected date either as a string (default) or as a Date object. To get a date as an object, pass the `true` parameter to the method.
 
 ~~~js
 const date1 = calendar.getValue(); // -> "20/08/19"
@@ -81,7 +81,7 @@ const date2 = calendar.getValue(true); // -> Tue Aug 20 2019 00:00:00 GMT+0300
 
 **Related sample**: [Calendar. Getting selected date](https://snippet.dhtmlx.com/k2vrfqj0)
 
-If you work with a calendar in the [range mode](calendar/configuring.md#range-mode) the **getValue()** method returns either an array of Date values or an array of string values with the start and end dates of the range.
+If you work with a calendar in the [range mode](calendar/configuring.md#range-mode), the `getValue()` method returns either an array of Date values or an array of string values with the start and end dates of the range.
 
 ~~~js
 // for a range calendar as an array of Date values 
@@ -94,12 +94,11 @@ const date = calendar.getValue(); // ->  ["03/06/19", "19/06/19"]
 
 ## Linking two calendars
 
-You can create two calendars and link them to provide the ability of selecting a date range. The first calendar will be used for setting the start date of the range, while the end date of the range will be specified in the
-second calendar.
+You can create two calendars and link them to select a date range. The first calendar sets the start date, the second sets the end date.
 
 ![Two linked Calendars selecting a date range across July and August in DHTMLX Suite](/img/calendar/date_range.png)
 
-Use the [](calendar/api/calendar_link_method.md) method and pass as a parameter the object of the second calendar to link the first calendar to. In the example below the [Change](calendar/api/calendar_change_event.md) event is intended to output the start and end dates of the selected range:
+Call the [](calendar/api/calendar_link_method.md) method on the first calendar and pass the second calendar object as a parameter. In the example below, the [Change](calendar/api/calendar_change_event.md) event outputs the start and end dates of the selected range:
 
 ~~~js
 const calendar = new dhx.Calendar("calendar1", { css: "dhx_calendar--bordered" });
@@ -149,12 +148,11 @@ calendar.setValue([new Date(2019,05,03), new Date(2019,05,19)]);
 calendar.setValue(["03/06/19", "15/06/19"]);
 ~~~
 
-In case a date has been successfully added into the calendar, the method will return *true*.
+If the method adds the date to the calendar successfully, it returns `true`.
 
 **Related sample**: [Calendar. Preset selected date](https://snippet.dhtmlx.com/vmg11002)
 
-{{note Please note that the format of date in the Calendar is defined by the [](calendar/api/calendar_dateformat_config.md) option. So, check that you've set the format of date you want to use in the calendar both in the
-**setValue()** method and in the **dateFormat** property. Otherwise, the default format (**"%d/%m/%y"**) will be used.}}
+{{note The [](calendar/api/calendar_dateformat_config.md) option defines the date format in Calendar. Set the format you want both in the `setValue()` method and in the `dateFormat` property. Otherwise, Calendar uses the default format, `"%d/%m/%y"`.}}
 
 ## Showing tooltips
 


### PR DESCRIPTION
- configuring: 13 API values moved from bold/italic to backticks, six "by default" openers, three "there is a possibility to" constructions, eight passive clauses and three "via" replaced
- customization: fixed the "calender" typo, `<style>` in backticks, list items capitalized, number agreement in "a new CSS class(es)"
- datepicker: fixed number agreement, three missing articles and two wrong prepositions ("attach into", "on click in"); class names in backticks where they refer to code identifiers
- headings left untouched: features.md links to their anchors

reviewed with the article-grammar skill; each page re-run after editing, which caught four defects introduced by the edits themselves