### PR TITLE
[update] grammar and style in Colorpicker guides

### DIFF
--- a/docs/calendar/index.md
+++ b/docs/calendar/index.md
@@ -12,7 +12,7 @@ DHTMLX Calendar is a component that allows users to view and select dates. You c
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Calendar:
+Learn how to build a full-featured DHTMLX Calendar:
 
 - [Features](calendar/features.md)
 
@@ -24,7 +24,7 @@ You can check the following page to learn how to build a full-featured DHTMLX Ca
 
 - To get just DHTMLX Calendar, download it from [our website](https://dhtmlx.com/docs/products/dhtmlxCalendar/download.shtml)
 - To get the whole JavaScript library of UI components, [download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX Calendar](https://snippet.dhtmlx.com/jkbfb202?tag=calendar)  
+- Try the [online samples for DHTMLX Calendar](https://snippet.dhtmlx.com/jkbfb202?tag=calendar)
   
 ## Guides
 

--- a/docs/chart/index.md
+++ b/docs/chart/index.md
@@ -14,7 +14,7 @@ Check [online samples for DHTMLX Chart](https://snippet.dhtmlx.com/bo82km4n?tag=
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Chart:
+Learn how to build a full-featured DHTMLX Chart:
 
 - [Features](chart/features.md)
 
@@ -26,7 +26,7 @@ You can check the following page to learn how to build a full-featured DHTMLX Ch
 
 - To get just DHTMLX Chart, download it from [our website](https://dhtmlx.com/docs/products/dhtmlxChart/download.shtml)
 - To get the whole JavaScript library of UI components [download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX Chart](https://snippet.dhtmlx.com/bo82km4n?tag=chart)
+- Try the [online samples for DHTMLX Chart](https://snippet.dhtmlx.com/bo82km4n?tag=chart)
 - To work with data of Chart check [DataCollection API](/data_collection/)
 
 ## Guides

--- a/docs/colorpicker/configuration.md
+++ b/docs/colorpicker/configuration.md
@@ -8,7 +8,7 @@ description: You can explore the configuration of Colorpicker in the documentati
 
 ## Custom colors in palette
 
-The palette of Colorpicker contains a set of default colors. They are enumerated below:
+The Colorpicker palette contains the following default colors:
 
 ~~~js
 const palette = [
@@ -29,7 +29,7 @@ const palette = [
 
 **Related sample**: [Colorpicker. Initialization](https://snippet.dhtmlx.com/ezk8rk4m)
 
-It is possible to redefine the structure of a palette via the [](colorpicker/api/colorpicker_palette_config.md) config option, and set an array of custom colors that will be shown on initialization of the component. 
+You can redefine the palette structure with the [](colorpicker/api/colorpicker_palette_config.md) configuration option and set an array of custom colors that the component shows on initialization.
 For example:
 
 ~~~js
@@ -52,13 +52,13 @@ const colorpicker = new dhx.Colorpicker("colorpicker_container", {
 
 ## Gray shades
 
-The default configuration of the Colorpicker palette includes a section with gray shades, which is shown at the top of palette. There is a possibility to hide this section showing just main colors: default or custom.
+The default Colorpicker palette includes a section with gray shades at the top of the palette. You can hide this section and leave only the main colors: default or custom.
 
 ![ColorPicker palette with the gray shades section hidden in DHTMLX Suite](/img/colorpicker/no_shades_palette.png)
 
 **Related sample**: [Colorpicker. Palette without gray shades](https://snippet.dhtmlx.com/b44fp8q2)
 
-Use the [](colorpicker/api/colorpicker_grayshades_config.md) configuration option for this purpose:
+Use the [](colorpicker/api/colorpicker_grayshades_config.md) configuration option to hide the section:
 
 ~~~js
 const colorpicker = new dhx.Colorpicker("colorpicker_container", {
@@ -70,8 +70,7 @@ const colorpicker = new dhx.Colorpicker("colorpicker_container", {
 
 ![ColorPicker palette with preset user-defined colors in the custom colors row in DHTMLX Suite](/img/colorpicker/custom_colors.png)
 
-When Colorpicker is rendered on a page, its list of custom (user-defined) colors is empty. You can change this configuration and specify custom colors that should be shown in the related section on initialization of 
-the component via the [](colorpicker/api/colorpicker_customcolors_config.md) configuration option. Colors should be specified as an array of strings in the Hex format:
+When Colorpicker appears on a page, its list of custom (user-defined) colors is empty. To fill this section on initialization, list the colors in the [](colorpicker/api/colorpicker_customcolors_config.md) configuration option. Specify colors as an array of strings in the Hex format:
 
 ~~~js
 const colorpicker = new dhx.Colorpicker("colorpicker_container", {
@@ -81,8 +80,7 @@ const colorpicker = new dhx.Colorpicker("colorpicker_container", {
 
 ## "palette" or "picker" mode only
 
-DHTMLX Colorpicker has two main modes: "palette" (default) and "picker". To initialize the component in the "picker" mode, set the [](colorpicker/api/colorpicker_pickeronly_config.md) property in the Colorpicker 
-configuration to *true*.
+DHTMLX Colorpicker supports two main modes: "palette" (default) and "picker". To initialize the component in the "picker" mode, set the [](colorpicker/api/colorpicker_pickeronly_config.md) property to `true` in the Colorpicker configuration.
 
 ~~~js
 const colorpicker = new dhx.Colorpicker("colorpicker_container", {
@@ -90,13 +88,13 @@ const colorpicker = new dhx.Colorpicker("colorpicker_container", {
 });
 ~~~
 
-In this mode the palette is not available and only the picker is displayed.
+In this mode, Colorpicker hides the palette and displays only the picker.
 
 ![ColorPicker in picker-only mode with a color gradient field and hex input in DHTMLX Suite](/img/colorpicker/picker_only.png)
 
 **Related sample**: [Colorpicker. Picker only](https://snippet.dhtmlx.com/5zlvvwpl)
 
-It is also possible to create the component in the palette mode only using the [](colorpicker/api/colorpicker_paletteonly_config.md) mode:
+You can also create the component in the palette mode only with the [](colorpicker/api/colorpicker_paletteonly_config.md) configuration option:
 
 ~~~js
 const colorpicker = new dhx.Colorpicker("colorpicker_container", {
@@ -106,13 +104,13 @@ const colorpicker = new dhx.Colorpicker("colorpicker_container", {
 
 ![ColorPicker in palette-only mode without the custom colors panel in DHTMLX Suite](/img/colorpicker/palette_only.png)
 
-{{note Note that in the **paletteOnly** mode the palette is displayed without the panel with custom (user-defined) colors.}}
+{{note In the `paletteOnly` mode, the palette does not include the panel with custom (user-defined) colors.}}
 
 **Related sample**: [Colorpicker. Disabled custom colors](https://snippet.dhtmlx.com/3d75mz19)
 
 ## Width of Colorpicker
 
-By default, the width of the component is 238 px. In case you change the number of colors in the palette, it may be necessary to adjust the width of Colorpicker accordingly. You can do this with the help of the [](colorpicker/api/colorpicker_width_config.md) property:
+The default width of the component is 238 px. If you change the number of colors in the palette, you may need to adjust the Colorpicker width accordingly. Use the [](colorpicker/api/colorpicker_width_config.md) property:
 
 ~~~js
 const colorpicker = new dhx.Colorpicker("colorpicker_container", {  
@@ -122,7 +120,7 @@ const colorpicker = new dhx.Colorpicker("colorpicker_container", {
 
 ## Color transparency
 
-The Colorpicker component provides the possibility to set the necessary color transparency in the "picker" mode by pulling the handle on the transparency scale. This feature is enabled by default. To switch it off, set the [transparency](colorpicker/api/colorpicker_transparency_config.md) configuration option to *false*:
+In the "picker" mode, users set color transparency when they pull the handle on the transparency scale. The default Colorpicker configuration includes this feature. To switch it off, set the [](colorpicker/api/colorpicker_transparency_config.md) configuration option to `false`:
 
 ~~~js
 const colorpicker = new dhx.Colorpicker("colorpicker", {

--- a/docs/colorpicker/customization.md
+++ b/docs/colorpicker/customization.md
@@ -8,15 +8,15 @@ description: You can explore the customization of Colorpicker in the documentati
 
 ## Styling
 
-There is a possibility to make changes in the look and feel of a colorpicker. 
+You can change the look and feel of Colorpicker.
 
 ![ColorPicker palette customized with circular color cells via custom CSS in DHTMLX Suite](/img/colorpicker/colorpicker_css.png)
 
 **Related sample**: [Colorpicker. Styling (custom CSS)](https://snippet.dhtmlx.com/mnwi3sp0)
 
-For this you need to take the following steps:
+Follow these steps:
 
-- add a new CSS class(es) with desired settings in the &lt;style&gt; section of your HTML page or in your file with styles (don't forget to include your file on the page in this case)
+- Add new CSS classes with the styles you need to the `<style>` section of your HTML page or to your stylesheet (remember to link the stylesheet on the page):
 
 ~~~html
 <style>
@@ -30,7 +30,7 @@ For this you need to take the following steps:
 </style>
 ~~~
 
-- specify the name of the created CSS class (or names of classes separated by spaces) as the value of the [css](colorpicker/api/colorpicker_css_config.md) property in the Colorpicker configuration:
+- Specify the class name (or several names separated by spaces) as the value of the [](colorpicker/api/colorpicker_css_config.md) property:
 
 ~~~js
 const colorpicker = new dhx.Colorpicker("colorpicker_container", {

--- a/docs/colorpicker/features.md
+++ b/docs/colorpicker/features.md
@@ -6,11 +6,11 @@ description: You can explore the features of Colorpicker in the documentation of
 
 # Features
 
-This page contains structured information that will help you to start working with DHTMLX Colorpicker and go into deep dive on its functionality.
+This page collects the guides and API references that help you start with DHTMLX Colorpicker and explore its functionality in depth.
 
 ## How to start with DHTMLX Colorpicker
 
-In this section you can find out the ways of Colorpicker initialization and localization, and learn how to integrate Colorpicker into your applications.
+This section explains how to initialize and localize Colorpicker, and how to integrate it into your applications.
 
 ### Initialization and localization
 
@@ -25,55 +25,55 @@ In this section you can find out the ways of Colorpicker initialization and loca
 
 | Topic                                                   | Description                                                                                                                                  |
 | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Backend integration](integration/suite_and_backend.md) | Learn how to connect DHTMLX Suite to a backend  ([Demo](https://github.com/DHTMLX/nodejs-suite-demo))                                        |
-| [Optimus](/optimus_guides/)                            | Learn how to use DHTMLX Optimus framework for creating  DHTMLX-based app <br>(recommended framework for creating apps with Suite components) |
+| [Backend integration](integration/suite_and_backend.md) | Learn how to connect DHTMLX Suite to a backend ([Demo](https://github.com/DHTMLX/nodejs-suite-demo))                                        |
+| [Optimus](/optimus_guides/)                            | Learn how to use the DHTMLX Optimus framework to create DHTMLX-based apps <br>(the recommended framework for apps built with Suite components) |
 | [React integration](integration/suite_and_react.md)     | Learn how to use DHTMLX Colorpicker with React ([Demo](https://github.com/DHTMLX/react-suite-demo))                                             |
 | [Angular integration](integration/suite_and_angular.md) | Learn how to use DHTMLX Colorpicker with Angular ([Demo](https://github.com/DHTMLX/angular-suite-demo))                                      |
 | [Vue integration](integration/suite_and_vue.md)         | Learn how to use DHTMLX Colorpicker with Vue.js ([Demo](https://github.com/DHTMLX/vue-suite-demo))                                           |
 
 ## How to configure Colorpicker
 
-In this section you will find out how to configure the modes of displaying Colorpicker.
+This section explains how to configure Colorpicker display modes.
 
 | Topic                                                                             | Description                                                                                                |
 | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| [Setting Colorpicker mode ("palette", "picker")](colorpicker/api/colorpicker_mode_config.md) | Learn how to configure the mode of displaying Colorpicker ([Example](https://snippet.dhtmlx.com/add0g4je)) |
+| [Setting Colorpicker mode ("palette", "picker")](colorpicker/api/colorpicker_mode_config.md) | Learn how to configure the Colorpicker display mode ([Example](https://snippet.dhtmlx.com/add0g4je)) |
 | [Displaying the picker only](colorpicker/configuration.md#palette-or-picker-mode-only)       | Learn how to hide the palette and display the picker only ([Example](https://snippet.dhtmlx.com/5zlvvwpl)) |
 | [Displaying the palette only](colorpicker/api/colorpicker_paletteonly_config.md)             | Learn how to hide the panel with custom colors ([Example](https://snippet.dhtmlx.com/3d75mz19))            |
 
- ## How to configure palette
+## How to configure palette
 
-In this section you will find out how to configure and customize palette.
+This section explains how to configure and customize the palette.
 
 | Topic                                                                    | Description                                                                                              |
 | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
 | [Hiding gray shades](colorpicker/configuration.md#gray-shades)                      | Learn how to hide gray shades at the top of the palette ([Example](https://snippet.dhtmlx.com/b44fp8q2)) |
-| [Displaying custom colors](colorpicker/configuration.md#list-of-custom-colors)      | Learn how to display a list of custom colors in the bottom part of Colorpicker                           |
+| [Displaying custom colors](colorpicker/configuration.md#list-of-custom-colors)      | Learn how to display a list of custom colors at the bottom of Colorpicker                           |
 | [Configuring custom palette](colorpicker/configuration.md#custom-colors-in-palette) | Learn how to display Colorpicker with a custom palette ([Example](https://snippet.dhtmlx.com/097jjhb8))  |
 
 ## How to customize Colorpicker and change its size
 
-In this section you can learn how to customize Colorpicker and change its width.
+This section explains how to customize Colorpicker and change its width.
 
 | Topic                                                          | Description                                                                                           |
 | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| [Width of Colorpicker](colorpicker/configuration.md#width-of-colorpicker) | Learn how to set the necessary width of Colorpicker                                                   |
+| [Width of Colorpicker](colorpicker/configuration.md#width-of-colorpicker) | Learn how to change the Colorpicker width                                                   |
 | [Styling (custom CSS)](colorpicker/customization.md)                      | Learn how to change the look and feel of Colorpicker ([Example](https://snippet.dhtmlx.com/mnwi3sp0)) |
-| [List of CSS classes](helpers/base_elements.md)            | A set of CSS classes provided by the DHTMLX library                                                   |
+| [List of CSS classes](helpers/base_elements.md)            | The set of CSS classes that the DHTMLX library provides                                                   |
 
 ## How to work with Colorpicker
 
-In this section you will find out how to set/get selected color, how to set/get custom colors which are displayed at the bottom of Colorpicker, how to change the current mode of Colorpicker, and more.
+This section explains how to set and get the selected color, how to manage the custom colors at the bottom of Colorpicker, and how to change the current Colorpicker mode.
 
 | Topic                                                                                      | Description                                                                                                                       |
 | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-| [Setting selection to a color](colorpicker/manipulating_colorpicker.md#settinggetting-selected-color) | Learn how to select a certain color in Colorpicker ([Example](https://snippet.dhtmlx.com/h6oc5qsq))                               |
+| [Setting selection to a color](colorpicker/manipulating_colorpicker.md#settinggetting-selected-color) | Learn how to select a color in Colorpicker ([Example](https://snippet.dhtmlx.com/h6oc5qsq))                               |
 | [Getting selected color](colorpicker/manipulating_colorpicker.md#settinggetting-selected-color)       | Learn how to get the code of a selected color                                                                                     |
-| [Setting custom colors](colorpicker/manipulating_colorpicker.md#settinggetting-custom-colors)         | Learn how to display custom colors in the bottom part of Colorpicker ([Example](https://snippet.dhtmlx.com/z9jfv3fg)) |
-| [Getting custom colors](colorpicker/manipulating_colorpicker.md#settinggetting-custom-colors)         | Learn how to return the codes of selected custom colors                                                                           |
-| [Changing Colorpicker mode](colorpicker/manipulating_colorpicker.md#settinggetting-current-mode)      | Learn how to change the current mode of Colorpicker ([Example](https://snippet.dhtmlx.com/0mhp5cp6))                              |
-| [Getting Colorpicker mode](colorpicker/manipulating_colorpicker.md#settinggetting-current-mode)       | Learn how to get the current mode of displaying Colorpicker                                                                       |
-| [Setting focus](colorpicker/manipulating_colorpicker.md#setting-focus-on-a-color)                     | Learn how to set focus on the specified value ([Example](https://snippet.dhtmlx.com/fg13r3uh))                                    |
+| [Setting custom colors](colorpicker/manipulating_colorpicker.md#settinggetting-custom-colors)         | Learn how to display custom colors at the bottom of Colorpicker ([Example](https://snippet.dhtmlx.com/z9jfv3fg)) |
+| [Getting custom colors](colorpicker/manipulating_colorpicker.md#settinggetting-custom-colors)         | Learn how to get the codes of the selected custom colors                                                                           |
+| [Changing Colorpicker mode](colorpicker/manipulating_colorpicker.md#settinggetting-current-mode)      | Learn how to change the current Colorpicker mode ([Example](https://snippet.dhtmlx.com/0mhp5cp6))                              |
+| [Getting Colorpicker mode](colorpicker/manipulating_colorpicker.md#settinggetting-current-mode)       | Learn how to get the current Colorpicker mode                                                                       |
+| [Setting focus](colorpicker/manipulating_colorpicker.md#setting-focus-on-a-color)                     | Learn how to set focus on a color ([Example](https://snippet.dhtmlx.com/fg13r3uh))                                    |
 
 ## How to work with Colorpicker events
 
@@ -86,7 +86,7 @@ This section explains how to work with Colorpicker events.
 
 ## API reference
 
-In this section you can find out corresponding references of Colorpicker API.
+This section links to the Colorpicker API reference.
 
 | Topic                                                          | Description                              |
 | -------------------------------------------------------------- | ---------------------------------------- |
@@ -96,13 +96,13 @@ In this section you can find out corresponding references of Colorpicker API.
 
 ## Common functionality
 
-In this section you will learn about common functionality of the library which can be useful while working with Colorpicker.
+This section covers common library features that help when you work with Colorpicker.
 
 | Topic                                                         | Description                                                   |
 | ------------------------------------------------------------- | ------------------------------------------------------------- |
 | [Touch support](common_features/touch_support.md)         | Learn how to work with touch support                          |
 | [TypeScript support](common_features/using_typescript.md) | Learn how to work with TypeScript                             |
-| [AwaitRedraw](helpers/await_redraw.md)                    | Learn how to perform the code after the component’s rendering |
+| [AwaitRedraw](helpers/await_redraw.md)                    | Learn how to run code after the component renders |
 
 ## Any questions left?
 

--- a/docs/colorpicker/handling_events.md
+++ b/docs/colorpicker/handling_events.md
@@ -8,7 +8,7 @@ description: You can explore the event handling of Colorpicker in the documentat
 
 ## Attaching event listeners
 
-You can attach event listeners with the **colorpicker.events.on()** method:
+You can attach event listeners with the `colorpicker.events.on()` method:
 
 ~~~js
 colorpicker.events.on("modeChange", function(view) {
@@ -16,13 +16,13 @@ colorpicker.events.on("modeChange", function(view) {
 });
 ~~~
 
-{{note The names of events are case-insensitive.}}
+{{note Event names are case-insensitive.}}
 
 **Related sample**: [Colorpicker. Events](https://snippet.dhtmlx.com/fllgaabo)
 
 ## Detaching event listeners
 
-To detach events, use **colorpicker.events.detach()**:
+You can detach event listeners with the `colorpicker.events.detach()` method:
 
 ~~~js
 colorpicker.events.on("modeChange", function(view) {
@@ -34,7 +34,7 @@ colorpicker.events.detach("modeChange");
 
 ## Calling events
 
-To call events, use **colorpicker.events.fire()**:
+You can call events with the `colorpicker.events.fire()` method:
 
 ~~~js
 colorpicker.events.fire("name",args);
@@ -43,4 +43,4 @@ colorpicker.events.fire("name",args);
 
 ## The list of events
 
-The full list of events is available in the related [API section](colorpicker/api/api_overview.md#events).
+The [API section](colorpicker/api/api_overview.md#events) lists all Colorpicker events.

--- a/docs/colorpicker/how_to_start.md
+++ b/docs/colorpicker/how_to_start.md
@@ -7,16 +7,16 @@ description: You can explore the initialization of Colorpicker in the documentat
 # Initialization
 
 :::info
-[Download the DHTMLX Colorpicker package](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) as a part of the DHTMLX Suite library
+[Download the DHTMLX Colorpicker package](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) as part of the DHTMLX Suite library
 :::
 
-There are two ways of initializing DHTMLX Colorpicker: inside a container or inside a popup. Both ways are described below in detail.
+You can initialize DHTMLX Colorpicker in two ways: inside a container or inside a popup.
 
-In general, to create DHTMLX Colorpicker on a page, you need to take the following simple steps:
+To create DHTMLX Colorpicker on a page, follow these steps:
 
 - [Include source files](#include-source-files)
 - [Initialize Colorpicker](#initialize-colorpicker) with the object constructor
-- [Set initially selected color (optional)](#select-initial-color-optional)
+- [Select the initial color (optional)](#select-initial-color-optional)
 
 ~~~html
 <!DOCTYPE html>
@@ -40,12 +40,12 @@ In general, to create DHTMLX Colorpicker on a page, you need to take the followi
 
 ## Include source files
 
-Unpack the downloaded package into a folder of your project.
+Unpack the downloaded package into your project folder.
 
-After that, create an HTML file and place full paths to JS and CSS files of the DHTMLX Suite library into the header of the file. The files are:
+Create an HTML file and place full paths to the DHTMLX Suite JS and CSS files in its header. The files are:
 
-- *suite.js*
-- *suite.css*
+- `suite.js`
+- `suite.css`
 
 ~~~html title="index.html"
 <script type="text/javascript" src="../../codebase/suite.js"></script>
@@ -58,13 +58,13 @@ You can initialize Colorpicker in a container or in a popup.
 
 ### Initialization in a container
 
-In this case you need to add a container for Colorpicker and give it an id, for example "colorpicker_container":
+In this case, add a container for Colorpicker and give the container an id, for example "colorpicker_container":
 
 ~~~html title="index.html"
 <div id="colorpicker_container"></div>
 ~~~
 
-and initialize Colorpicker with the `dhx.Colorpicker` object constructor like this:
+Initialize Colorpicker with the `dhx.Colorpicker` object constructor:
 
 ~~~js title="index.js"
 // creating ColorPicker
@@ -78,28 +78,28 @@ const colorpicker = new dhx.Colorpicker("colorpicker_container", {
 
 The constructor takes two parameters:
 
-- the HTML container for ColorPicker
-- an object with configuration properties ([see the full list below](#configuration-properties)). If this argument is not passed to the constructor, the settings will be default.
+- The HTML container for Colorpicker.
+- An object with configuration properties ([see the full list below](#configuration-properties)). If you omit this argument, Colorpicker uses default settings.
 
 
 ### Initialization in a popup
 
-This variant presupposes that you create a popup first and then attach a colorpicker into it. 
+In this case, you create a popup first and then attach Colorpicker to it.
 
-- use corresponding object constructors to create a colorpicker and a popup objects. Note that in this case *null* is used instead of container for Colorpicker:
+- Use the object constructors to create the Colorpicker and Popup objects. Pass `null` instead of a container for Colorpicker:
 
 ~~~js
 const colorpicker = new dhx.Colorpicker(null, { customColors: ["#f2f2f2"] });
 const popup = new dhx.Popup();
 ~~~
 
-- attach the colorpicker to the popup using the [](popup/api/popup_attach_method.md) method of Popup:
+- Attach Colorpicker to the popup with the [](popup/api/popup_attach_method.md) method of Popup:
 
 ~~~js
 popup.attach(colorpicker);
 ~~~
 
-- use the [show()](popup/api/popup_show_method.md) and [hide()](popup/api/popup_hide_method.md) methods of Popup to control when a popup with color picker should be shown/hidden. For example:
+- Use the [show()](popup/api/popup_show_method.md) and [hide()](popup/api/popup_hide_method.md) methods of Popup to show and hide the popup with Colorpicker. For example:
 
 ~~~js
 popup.show("showButton");
@@ -115,11 +115,11 @@ colorpicker.events.on("colorChange", function (color) {
 
 ### Configuration properties
 
-The detailed information on Colorpicker configuration options can be found in the [Colorpicker API overview](colorpicker/api/api_overview.md#properties) article.
+The [Colorpicker API overview](colorpicker/api/api_overview.md#properties) article describes Colorpicker configuration options in detail.
 
 ## Select initial color (optional)
 
-You can specify the color that should be selected in the palette after Colorpicker initialization with the help of the [](colorpicker/api/colorpicker_setvalue_method.md) method:
+Use the [](colorpicker/api/colorpicker_setvalue_method.md) method to select a color in the palette after Colorpicker initialization:
 
 ~~~js
 const colorpicker = new dhx.Colorpicker("colorpicker_container", {

--- a/docs/colorpicker/index.md
+++ b/docs/colorpicker/index.md
@@ -6,8 +6,8 @@ description: You can have an overview of Colorpicker in the documentation of the
 
 # Colorpicker overview
 
-DHTMLX Colorpicker is a smart component for selecting colors that can be used both as an inline control and as a popup dialog box. 
-It possesses easy-to-configure interface that can be simply localized and customized depending on the need of the project and complete API for handy control over the behavior of the component. 
+DHTMLX Colorpicker is a component for selecting colors. It works both as an inline control and as a popup dialog box.
+You can localize and customize the Colorpicker interface for your project. The complete API gives you control over the component behavior.
 
 Check [online samples for DHTMLX Colorpicker](https://snippet.dhtmlx.com/097jjhb8?tag=colorpicker).
 
@@ -30,7 +30,7 @@ You can check the following page to learn how to build a full-featured DHTMLX Co
 
 ## Guides
 
-Covers the processes of creating, configuring, localizing, customizing ColorPicker, and working with it.
+These guides explain how to create, configure, localize, and customize Colorpicker, and how to work with it.
 
 - [](colorpicker/how_to_start.md)
 - [](colorpicker/configuration.md)

--- a/docs/colorpicker/index.md
+++ b/docs/colorpicker/index.md
@@ -15,7 +15,7 @@ Check [online samples for DHTMLX Colorpicker](https://snippet.dhtmlx.com/097jjhb
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Colorpicker:
+Learn how to build a full-featured DHTMLX Colorpicker:
 
 - [Features](colorpicker/features.md)
 
@@ -25,8 +25,8 @@ You can check the following page to learn how to build a full-featured DHTMLX Co
 
 ## Related resources
 
-- You can get DHTMLX Colorpicker as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX Colorpicker](https://snippet.dhtmlx.com/097jjhb8?tag=colorpicker)  
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX Colorpicker as part of the Suite library
+- Try the [online samples for DHTMLX Colorpicker](https://snippet.dhtmlx.com/097jjhb8?tag=colorpicker)
 
 ## Guides
 

--- a/docs/colorpicker/manipulating_colorpicker.md
+++ b/docs/colorpicker/manipulating_colorpicker.md
@@ -6,11 +6,11 @@ description: You can explore how to work with Colorpicker in the documentation o
 
 # Work with ColorPicker
 
-The API of Colorpicker helps you control the functionality of the component through a set of handy methods.
+The Colorpicker API helps you control the component through a set of methods.
 
 ## Setting/getting selected color
 
-You can select a certain color in the Colorpicker via the [setValue()](colorpicker/api/colorpicker_setvalue_method.md) method. It takes as a parameter the code of a color from the palette in the Hex format.
+You can select a color in Colorpicker with the [setValue()](colorpicker/api/colorpicker_setvalue_method.md) method. It takes the code of a color from the palette in the Hex format as a parameter.
 
 ~~~js
 colorpicker.setValue("#F9E6AD");
@@ -18,7 +18,7 @@ colorpicker.setValue("#F9E6AD");
 
 **Related sample**: [Colorpicker. Set value](https://snippet.dhtmlx.com/h6oc5qsq)
 
-It is also possible to get the code of a color selected in the color picker using the [getValue()](colorpicker/api/colorpicker_getvalue_method.md) method.
+You can also get the code of the color selected in Colorpicker with the [getValue()](colorpicker/api/colorpicker_getvalue_method.md) method.
 
 ~~~js
 colorpicker.getValue(); // -> "#F9E6AD"
@@ -26,7 +26,7 @@ colorpicker.getValue(); // -> "#F9E6AD"
 
 ## Setting/getting custom colors
 
-To set custom colors that will be displayed at the bottom of the palette, make use of the [setCustomColors()](colorpicker/api/colorpicker_setcustomcolors_method.md) method. It takes an array with custom colors as a parameter.
+Use the [setCustomColors()](colorpicker/api/colorpicker_setcustomcolors_method.md) method to set custom colors that appear at the bottom of the palette. It takes an array of custom colors as a parameter.
 
 ~~~js
 colorpicker.setCustomColors(["#f2f2f2","#8ac5d9","#ec9875","#7a8523"]);
@@ -34,7 +34,7 @@ colorpicker.setCustomColors(["#f2f2f2","#8ac5d9","#ec9875","#7a8523"]);
 
 **Related sample**: [Colorpicker. Set custom colors](https://snippet.dhtmlx.com/z9jfv3fg)
 
-To get a collection of selected custom colors, use the [getCustomColors()](colorpicker/api/colorpicker_getcustomcolors_method.md) method. It returns selected colors as an array of strings in the Hex format.
+Use the [getCustomColors()](colorpicker/api/colorpicker_getcustomcolors_method.md) method to get the selected custom colors. It returns the colors as an array of strings in the Hex format.
 
 ~~~js
 colorpicker.setCustomColors(["#f2f2f2","#8ac5d9","#ec9875","#7a8523"]);
@@ -45,8 +45,8 @@ colorpicker.getCustomColors();
 
 ## Setting/getting current mode
 
-By default, Colorpicker is rendered in the "palette" mode. There is also the "picker" view in the component which is shown when a user selects a custom color. 
-You can choose what view should be shown with the help of the [setCurrentMode()](colorpicker/api/colorpicker_setcurrentmode_method.md) method. It takes the name of the mode to show as a parameter.
+The default Colorpicker mode is "palette". The component also has the "picker" mode that appears when a user selects a custom color.
+Use the [setCurrentMode()](colorpicker/api/colorpicker_setcurrentmode_method.md) method to choose the mode to show. It takes the mode name as a parameter.
 
 ~~~js
 colorpicker.setCurrentMode("picker");
@@ -54,7 +54,7 @@ colorpicker.setCurrentMode("picker");
 
 **Related sample**: [Colorpicker. Set current mode](https://snippet.dhtmlx.com/0mhp5cp6)
 
-To get the current view of ColorPicker, make use of the [getCurrentMode()](colorpicker/api/colorpicker_getcurrentmode_method.md) method. It returns a string with the name of the view: "palette" or "picker".
+Use the [getCurrentMode()](colorpicker/api/colorpicker_getcurrentmode_method.md) method to get the current Colorpicker mode. It returns a string with the mode name: "palette" or "picker".
 
 ~~~js
 colorpicker.setCurrentMode(mode);
@@ -65,7 +65,7 @@ colorpicker.getCurrentMode();
 
 ## Setting focus on a color
 
-To set focus on a certain color in the palette, make use of the [setFocus()](colorpicker/api/colorpicker_setfocus_method.md) method. As a parameter it takes a string with the code of a color (in the Hex format) to set focus on.
+Use the [setFocus()](colorpicker/api/colorpicker_setfocus_method.md) method to set focus on a color in the palette. It takes a string with the color code in the Hex format as a parameter.
 
 ~~~js
 colorpicker.setFocus("#BDF0E9");

--- a/docs/combobox/index.md
+++ b/docs/combobox/index.md
@@ -14,7 +14,7 @@ Check [online samples for DHTMLX ComboBox](https://snippet.dhtmlx.com/ui7pi7ty?t
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Combobox:
+Learn how to build a full-featured DHTMLX Combobox:
 
 - [Features](combobox/features.md)
 
@@ -24,8 +24,8 @@ You can check the following page to learn how to build a full-featured DHTMLX Co
 
 ## Related resources
 
-- You can get DHTMLX ComboBox as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX ComboBox](https://snippet.dhtmlx.com/ui7pi7ty?tag=combobox)
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX ComboBox as part of the Suite library
+- Try the [online samples for DHTMLX ComboBox](https://snippet.dhtmlx.com/ui7pi7ty?tag=combobox)
 - To work with data of ComboBox check [DataCollection API](/data_collection/)
 
 ## Guides

--- a/docs/dataview/index.md
+++ b/docs/dataview/index.md
@@ -14,7 +14,7 @@ Check [online samples for DHTMLX DataView](https://snippet.dhtmlx.com/j1yv94o8?t
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX DataView:
+Learn how to build a full-featured DHTMLX DataView:
 
 - [Features](dataview/features.md)
 
@@ -24,8 +24,8 @@ You can check the following page to learn how to build a full-featured DHTMLX Da
 
 ## Related resources
 
-- You can get DHTMLX DataView as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX DataView](https://snippet.dhtmlx.com/j1yv94o8?tag=dataview)
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX DataView as part of the Suite library
+- Try the [online samples for DHTMLX DataView](https://snippet.dhtmlx.com/j1yv94o8?tag=dataview)
 - To work with data of DataView check [DataCollection API](/data_collection/)
 
 ## Guides

--- a/docs/form/index.md
+++ b/docs/form/index.md
@@ -13,7 +13,7 @@ Check [online samples for DHTMLX Form](https://snippet.dhtmlx.com/ikyyekxq?tag=f
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Form:
+Learn how to build a full-featured DHTMLX Form:
 
 - [Features](form/features.md)
 
@@ -23,8 +23,8 @@ You can check the following page to learn how to build a full-featured DHTMLX Fo
 
 ## Related resources
 
-- You can get DHTMLX Form as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX Form](https://snippet.dhtmlx.com/ikyyekxq?tag=form)  
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX Form as part of the Suite library
+- Try the [online samples for DHTMLX Form](https://snippet.dhtmlx.com/ikyyekxq?tag=form)
 
 ## Guides
 

--- a/docs/grid/index.md
+++ b/docs/grid/index.md
@@ -14,7 +14,7 @@ Check [online samples for DHTMLX Grid](https://snippet.dhtmlx.com/1mxmshax?tag=g
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Grid:
+Learn how to build a full-featured DHTMLX Grid:
 
 - [Features](grid/features.md)
 
@@ -26,7 +26,7 @@ You can check the following page to learn how to build a full-featured DHTMLX Gr
 
 - To get just DHTMLX Grid, download it from [our website](https://dhtmlx.com/docs/products/dhtmlxGrid/download.shtml)
 - To get the whole JavaScript library of UI components [download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX Grid](https://snippet.dhtmlx.com/1mxmshax?tag=grid)
+- Try the [online samples for DHTMLX Grid](https://snippet.dhtmlx.com/1mxmshax?tag=grid)
 - To work with data of Grid check [DataCollection API](/data_collection/)
 - To work with data of Grid in the TreeGrid mode check [TreeCollection API](/tree_collection/)
 

--- a/docs/grid/initialization.md
+++ b/docs/grid/initialization.md
@@ -51,7 +51,7 @@ To initialize DHTMLX Grid on a page, you need to take the following simple steps
 
 Unpack the downloaded package into a folder of your project.
 
-After that, create an HTML file and place full paths to JS and CSS files of DHTMLX Grid into the header of the created file. The Grid component can be used standalone or as a part of the Suite library.
+After that, create an HTML file and place full paths to JS and CSS files of DHTMLX Grid into the header of the created file. The Grid component can be used standalone or as part of the Suite library.
 
 **If you use DHTMLX Grid standalone**, you need to include 2 files:
 

--- a/docs/layout/index.md
+++ b/docs/layout/index.md
@@ -13,7 +13,7 @@ Check [online samples for DHTMLX Layout](https://snippet.dhtmlx.com/f1f49n35?tag
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Layout:
+Learn how to build a full-featured DHTMLX Layout:
 
 - [Features](layout/features.md)
 
@@ -23,8 +23,8 @@ You can check the following page to learn how to build a full-featured DHTMLX La
 
 ## Related resources
 
-- You can get DHTMLX Layout as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX Layout](https://snippet.dhtmlx.com/f1f49n35?tag=layout)  
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX Layout as part of the Suite library
+- Try the [online samples for DHTMLX Layout](https://snippet.dhtmlx.com/f1f49n35?tag=layout)
 
 ## Guides
 

--- a/docs/list/index.md
+++ b/docs/list/index.md
@@ -13,7 +13,7 @@ It allows you to arrange multiple objects with similar properties within a singl
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX List:
+Learn how to build a full-featured DHTMLX List:
 
 - [Features](list/features.md)
 
@@ -23,8 +23,8 @@ You can check the following page to learn how to build a full-featured DHTMLX Li
 
 ## Related resources
 
-- You can get DHTMLX List as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX List](https://snippet.dhtmlx.com/0sorkczm?tag=list)
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX List as part of the Suite library
+- Try the [online samples for DHTMLX List](https://snippet.dhtmlx.com/0sorkczm?tag=list)
 - To work with data of List check [DataCollection API](/data_collection/)
 
 ## Guides

--- a/docs/menu/index.md
+++ b/docs/menu/index.md
@@ -12,7 +12,7 @@ DHTMLX Menu is a component that provides an easy way to add a drop down menu to 
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Menu:
+Learn how to build a full-featured DHTMLX Menu:
 
 - [Features](menu/features.md)
 
@@ -22,8 +22,8 @@ You can check the following page to learn how to build a full-featured DHTMLX Me
 
 ## Related resources
 
-- You can get DHTMLX Menu as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX Menu](https://snippet.dhtmlx.com/nk65jfmx?tag=menu)
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX Menu as part of the Suite library
+- Try the [online samples for DHTMLX Menu](https://snippet.dhtmlx.com/nk65jfmx?tag=menu)
 - To work with data of Menu check [TreeCollection API](/tree_collection/)
 
 ## Guides

--- a/docs/message/index.md
+++ b/docs/message/index.md
@@ -14,14 +14,14 @@ Check [online samples for DHTMLX Message](https://snippet.dhtmlx.com/tfiqt79l?ta
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Message:
+Learn how to build a full-featured DHTMLX Message:
 
 - [Features](message/features.md)
 
 ## Related resources
 
-- You can get DHTMLX Message as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX Message](https://snippet.dhtmlx.com/tfiqt79l?tag=message)  
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX Message as part of the Suite library
+- Try the [online samples for DHTMLX Message](https://snippet.dhtmlx.com/tfiqt79l?tag=message)
 
 ## Guides
 

--- a/docs/pagination/index.md
+++ b/docs/pagination/index.md
@@ -17,7 +17,7 @@ The component is easy-to-use and provides handy navigation that allows you to qu
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Pagination:
+Learn how to build a full-featured DHTMLX Pagination:
 
 - [Features](pagination/features.md)
 
@@ -27,8 +27,8 @@ You can check the following page to learn how to build a full-featured DHTMLX Pa
 
 ## Related resources
 
-- You can get DHTMLX Pagination as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX Pagination](https://snippet.dhtmlx.com/05r4s63b?tag=pagination)  
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX Pagination as part of the Suite library
+- Try the [online samples for DHTMLX Pagination](https://snippet.dhtmlx.com/05r4s63b?tag=pagination)
 
 ## Guides
 

--- a/docs/popup/index.md
+++ b/docs/popup/index.md
@@ -14,7 +14,7 @@ Mainly, the component is applied for showing a pop-up content on some action, su
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Popup:
+Learn how to build a full-featured DHTMLX Popup:
 
 - [Features](popup/features.md)
 
@@ -24,8 +24,8 @@ You can check the following page to learn how to build a full-featured DHTMLX Po
 
 ## Related resources
 
-- You can get DHTMLX Popup as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX Popup](https://snippet.dhtmlx.com/bz1ekc71?tag=popup) 
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX Popup as part of the Suite library
+- Try the [online samples for DHTMLX Popup](https://snippet.dhtmlx.com/bz1ekc71?tag=popup)
 
 ## Guides
 

--- a/docs/ribbon/index.md
+++ b/docs/ribbon/index.md
@@ -12,7 +12,7 @@ DHTMLX Ribbon is an advanced version of DHTMLX Toolbar. It aggregates commands a
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Ribbon:
+Learn how to build a full-featured DHTMLX Ribbon:
 
 - [Features](ribbon/features.md)
 
@@ -22,8 +22,8 @@ You can check the following page to learn how to build a full-featured DHTMLX Ri
 
 ## Related resources
 
-- You can get DHTMLX Ribbon as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX Ribbon](https://snippet.dhtmlx.com/3djaib6o?tag=ribbon)
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX Ribbon as part of the Suite library
+- Try the [online samples for DHTMLX Ribbon](https://snippet.dhtmlx.com/3djaib6o?tag=ribbon)
 - To work with data of Ribbon check [TreeCollection API](/tree_collection/)
 
 ## Guides

--- a/docs/sidebar/index.md
+++ b/docs/sidebar/index.md
@@ -13,7 +13,7 @@ Check [online samples for DHTMLX Sidebar](https://snippet.dhtmlx.com/3mhhvvcr?ta
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Sidebar:
+Learn how to build a full-featured DHTMLX Sidebar:
 
 - [Features](sidebar/features.md)
 
@@ -23,8 +23,8 @@ You can check the following page to learn how to build a full-featured DHTMLX Si
 
 ## Related resources
 
-- You can get DHTMLX Sidebar as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX Sidebar](https://snippet.dhtmlx.com/3mhhvvcr?tag=sidebar)
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX Sidebar as part of the Suite library
+- Try the [online samples for DHTMLX Sidebar](https://snippet.dhtmlx.com/3mhhvvcr?tag=sidebar)
 - To work with data of Sidebar check [TreeCollection API](/tree_collection/)
 
 ## Guides

--- a/docs/slider/index.md
+++ b/docs/slider/index.md
@@ -14,7 +14,7 @@ Check [online samples for DHTMLX Slider](https://snippet.dhtmlx.com/jsfxnplp?tag
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Slider:
+Learn how to build a full-featured DHTMLX Slider:
 
 - [Features](slider/features.md)
 
@@ -24,8 +24,8 @@ You can check the following page to learn how to build a full-featured DHTMLX Sl
 
 ## Related resources
 
-- You can get DHTMLX Slider as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX Slider](https://snippet.dhtmlx.com/jsfxnplp?tag=slider)  
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX Slider as part of the Suite library
+- Try the [online samples for DHTMLX Slider](https://snippet.dhtmlx.com/jsfxnplp?tag=slider)
 
 ## Guides
 

--- a/docs/tabbar/index.md
+++ b/docs/tabbar/index.md
@@ -14,7 +14,7 @@ Check [online samples for DHTMLX Tabbar](https://snippet.dhtmlx.com/xq6k0tts?tag
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Tabbar:
+Learn how to build a full-featured DHTMLX Tabbar:
 
 - [Features](tabbar/features.md)
 
@@ -24,8 +24,8 @@ You can check the following page to learn how to build a full-featured DHTMLX Ta
 
 ## Related resources
 
-- You can get DHTMLX Tabbar as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX Tabbar](https://snippet.dhtmlx.com/xq6k0tts?tag=tabbar)  
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX Tabbar as part of the Suite library
+- Try the [online samples for DHTMLX Tabbar](https://snippet.dhtmlx.com/xq6k0tts?tag=tabbar)
 
 ## Guides
 

--- a/docs/timepicker/index.md
+++ b/docs/timepicker/index.md
@@ -13,7 +13,7 @@ Check [online samples for DHTMLX TimePicker](https://snippet.dhtmlx.com/u9ge1a4z
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Timepicker:
+Learn how to build a full-featured DHTMLX Timepicker:
 
 - [Features](timepicker/features.md)
 
@@ -23,8 +23,8 @@ You can check the following page to learn how to build a full-featured DHTMLX Ti
 
 ## Related resources
 
-- You can get DHTMLX TimePicker as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX TimePicker](https://snippet.dhtmlx.com/u9ge1a4z?tag=timepicker)  
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX TimePicker as part of the Suite library
+- Try the [online samples for DHTMLX TimePicker](https://snippet.dhtmlx.com/u9ge1a4z?tag=timepicker)
 
 ## Guides
 

--- a/docs/toolbar/index.md
+++ b/docs/toolbar/index.md
@@ -13,7 +13,7 @@ Being a great tool for fast and handy navigation, it will make work with your ap
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Toolbar:
+Learn how to build a full-featured DHTMLX Toolbar:
 
 - [Features](toolbar/features.md)
 
@@ -23,8 +23,8 @@ You can check the following page to learn how to build a full-featured DHTMLX To
 
 ## Related resources
 
-- You can get DHTMLX Toolbar as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX Toolbar](https://snippet.dhtmlx.com/nie9tuks?tag=toolbar)
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX Toolbar as part of the Suite library
+- Try the [online samples for DHTMLX Toolbar](https://snippet.dhtmlx.com/nie9tuks?tag=toolbar)
 - To work with data of Toolbar check [TreeCollection API](/tree_collection/)
 
 ## Guides

--- a/docs/tree/index.md
+++ b/docs/tree/index.md
@@ -14,7 +14,7 @@ Check [online samples for DHTMLX Tree](https://snippet.dhtmlx.com/hg3f50td?tag=t
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Tree:
+Learn how to build a full-featured DHTMLX Tree:
 
 - [Features](tree/features.md)
 
@@ -26,7 +26,7 @@ You can check the following page to learn how to build a full-featured DHTMLX Tr
 
 - To get just DHTMLX Tree, download it from [our website](https://dhtmlx.com/docs/products/dhtmlxTree/download.shtml)
 - To get the whole JavaScript library of UI components [download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX Tree](https://snippet.dhtmlx.com/hg3f50td?tag=tree)
+- Try the [online samples for DHTMLX Tree](https://snippet.dhtmlx.com/hg3f50td?tag=tree)
 - To work with data of Tree check [TreeCollection API](/tree_collection/)
   
 ## Guides

--- a/docs/tree/initialization_of_dhtmlxtree.md
+++ b/docs/tree/initialization_of_dhtmlxtree.md
@@ -44,7 +44,7 @@ To initialize DHTMLX Tree on a page, you need to take the following simple steps
 
 Unpack the downloaded package into a folder of your project.
 
-After that, create an HTML file and place full paths to JS and CSS files of DHTMLX Tree into the header of the created file. The Tree component can be used standalone or as a part of the Suite library.
+After that, create an HTML file and place full paths to JS and CSS files of DHTMLX Tree into the header of the created file. The Tree component can be used standalone or as part of the Suite library.
 
 **If you use DHTMLX Tree standalone**, you need to include 2 files:
 

--- a/docs/window/index.md
+++ b/docs/window/index.md
@@ -14,7 +14,7 @@ Check [online samples for DHTMLX Window](https://snippet.dhtmlx.com/nthbfzfr?tag
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX Window:
+Learn how to build a full-featured DHTMLX Window:
 
 - [Features](window/features.md)
 
@@ -24,8 +24,8 @@ You can check the following page to learn how to build a full-featured DHTMLX Wi
 
 ## Related resources
 
-- You can get DHTMLX Window as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX Window](https://snippet.dhtmlx.com/nthbfzfr?tag=window)
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX Window as part of the Suite library
+- Try the [online samples for DHTMLX Window](https://snippet.dhtmlx.com/nthbfzfr?tag=window)
 
 ## Guides
 


### PR DESCRIPTION
- replace "It is possible to"/"There is a possibility to" openers with active phrasing
- rewrite passive constructions so Colorpicker or the reader is the subject
- put code values and property names in backticks instead of italic/bold
- drop vague "via" and "with the help of" in favour of direct verbs
- fix the missing article in "at the top of the palette"
- call paletteOnly a configuration option, not a mode
- unify the transparency link with the other auto-labeled API links