### PR TITLE
[update] grammar and style in DataView guides

### DIFF
--- a/docs/dataview/configuration.md
+++ b/docs/dataview/configuration.md
@@ -12,7 +12,7 @@ description: You can explore the configuration of DataView in the documentation 
 
 **Related sample**: [Dataview. Arrow navigation](https://snippet.dhtmlx.com/u7mgoly9)
 
-The DataView component provides the possibility to navigate its items with arrow keys. You can enable this functionality using the [](dataview/api/dataview_keynavigation_config.md) property:
+The DataView component lets you navigate its items with arrow keys. Enable this behavior with the [](dataview/api/dataview_keynavigation_config.md) property:
 
 ~~~js
 const dataview = new dhx.DataView("dataview_container", {
@@ -20,7 +20,7 @@ const dataview = new dhx.DataView("dataview_container", {
 });
 ~~~
 
-As a value of this option you can use either *true/false* to switch it on/off, or you can specify a *function* that will define some custom navigation logic.
+The option takes either `true` or `false` to turn navigation on and off, or a `function` that defines custom navigation logic.
 
 ### Default shortcut keys
 
@@ -28,27 +28,27 @@ As a value of this option you can use either *true/false* to switch it on/off, o
     <tbody>
         <tr>
             <td><b>ArrowUp</b></td>
-            <td>moves focus to the previous vertical item</td>
+            <td>moves focus to the item above</td>
         </tr>
         <tr>
             <td><b>ArrowDown</b></td>
-            <td>moves focus to the next vertical item</td>
+            <td>moves focus to the item below</td>
         </tr>
         <tr>
             <td><b>ArrowLeft</b></td>
-            <td>moves focus to the previous horizontal item</td>
+            <td>moves focus to the item on the left</td>
         </tr>
         <tr>
             <td><b>ArrowRight</b></td>
-            <td>moves focus to the next horizontal item</td>
+            <td>moves focus to the item on the right</td>
         </tr>
         <tr>
             <td><b>Enter/Shift+Enter/Ctrl+Enter</b></td>
-            <td>adds selection to an item in focus</td>
+            <td>selects the focused item</td>
         </tr>
         <tr>
             <td><b>Enter</b></td>
-            <td>adds selection to an item in focus, activates editor for the selected item (when the "editable" property is enabled)</td>
+            <td>selects the focused item and opens the editor for it (when the "editable" property is enabled)</td>
         </tr>
         <tr>
             <td><b>Ctrl+A</b></td>
@@ -59,12 +59,11 @@ As a value of this option you can use either *true/false* to switch it on/off, o
 
 ## Drag-n-drop of items
 
-DHTMLX DataView supports drag-n-drop of items between dataviews in several modes. To begin with, you should specify the [](dataview/api/dataview_dragmode_config.md) property in the configuration object of DataView.
-Then define which mode you need:
+DHTMLX DataView supports drag-n-drop of items between dataviews in three modes. Specify the [](dataview/api/dataview_dragmode_config.md) property in the DataView configuration object and choose the mode you need:
 
-- "target" - a dataview takes items from other dataviews, while its items can't be dragged out of it
-- "source" - a dataview allows dragging its items out and can't take items from other dataviews
-- "both" - a dataview both takes items from other dataviews and allows dragging its items out as well
+- `target` — a dataview takes items from other dataviews, but its items cannot be dragged out
+- `source` — a dataview lets you drag its items out, but cannot take items from other dataviews
+- `both` — a dataview takes items from other dataviews and lets you drag its items out
 
 ~~~js
 const dataview = new dhx.DataView("dataview_container", { 
@@ -72,8 +71,7 @@ const dataview = new dhx.DataView("dataview_container", {
 });
 ~~~
 
-In order to provide the possiblity of dragging several items between dataviews, you should enable the [](dataview/api/dataview_multiselection_config.md) property
-in addition to **dragMode**:
+To drag several items between dataviews, enable the [](dataview/api/dataview_multiselection_config.md) property in addition to `dragMode`:
 
 ~~~js
 const dataview = new dhx.DataView("dataview_container", { 
@@ -82,14 +80,14 @@ const dataview = new dhx.DataView("dataview_container", {
 });
 ~~~
 
-Read more about multiselection in DataView [below](#multiple-selection-of-items).
+For details, see [Multiple selection of items](#multiple-selection-of-items).
 
 **Related sample**: [Dataview. Drag'n'drop](https://snippet.dhtmlx.com/nia2e5a9)
 
 ### Copying dragged item
 
-Instead of moving a dragged item to a new position in the same or a different dataview, you can copy it. 
-Use the [](dataview/api/dataview_dragcopy_config.md) option in the configuration object of a dataview.
+Instead of moving a dragged item to a new position in the same or a different dataview, you can copy it.
+Use the [](dataview/api/dataview_dragcopy_config.md) option in the dataview configuration object.
 
 ~~~js
 const source = new dhx.DataView("dataview-source", {dragMode: "source", dragCopy: true});
@@ -104,7 +102,7 @@ const target = new dhx.DataView("dataview-target", {dragMode: "target", dragCopy
 
 **Related sample**: [Dataview. Inline editing](https://snippet.dhtmlx.com/m8fbqcza)
 
-You can enable the possibility to edit DataView items with the help of the [](dataview/api/dataview_editable_config.md) configuration option:
+You can make DataView items editable with the [](dataview/api/dataview_editable_config.md) configuration option:
 
 ~~~js
 const dataview = new dhx.DataView("dataview_container", {editable:true});
@@ -116,7 +114,7 @@ const dataview = new dhx.DataView("dataview_container", {editable:true});
 
 **Related sample**: [Dataview. Setup Dataview item height](https://snippet.dhtmlx.com/cth9mwrf)
 
-You can specify the necessary height of a Dataview item and set it before initialization of Dataview via the [itemHeight](dataview/api/dataview_itemheight_config.md) property either as a number:
+Set the height of a DataView item before initialization with the [itemHeight](dataview/api/dataview_itemheight_config.md) property, either as a number:
 
 ~~~js {3}
 // sets the height of an item as a number
@@ -125,7 +123,7 @@ const dataview = new dhx.DataView("dataview_container", {
 });
 ~~~
 
-or as a string value
+You can also set it as a string value:
 
 ~~~js {3}
 // sets the height of an item as a string value
@@ -134,27 +132,31 @@ const dataview = new dhx.DataView("dataview_container", {
 });
 ~~~
 
-{{note The usage of the *CSS calc() function* within the [](dataview/api/dataview_itemheight_config.md) property is not possible.}}
+:::note
+You cannot use the CSS `calc()` function in the [](dataview/api/dataview_itemheight_config.md) property.
+:::
 
-## Height of the Dataview
+## Height of the DataView
 
 ![DHTMLX DataView with a single row of animal cards limited by a fixed widget height in DHTMLX Suite](/img/dataview/dataview_height.png)
 
 **Related sample**: [Dataview. Setup Dataview height](https://snippet.dhtmlx.com/g1k2l4q0)
 
-You can define the desired height of a dataview via the [height](dataview/api/dataview_height_config.md) configuration option as easy as that:
+You can set the height of a DataView with the [height](dataview/api/dataview_height_config.md) configuration option:
 
 ~~~js
 const dataview = new dhx.DataView("dataview_container", {height: 150});
 ~~~
 
-You can also use a string value for setting the height of Dataview:
+You can also use a string value to set the DataView height:
 
 ~~~js
 const dataview = new dhx.DataView("dataview_container", {height: "400px"});
 ~~~
 
-{{note The usage of the *CSS calc() function* within the [](dataview/api/dataview_height_config.md) property is not possible.}}
+:::note
+You cannot use the CSS `calc()` function in the [](dataview/api/dataview_height_config.md) property.
+:::
 
 ## Margins around DataView items
 
@@ -162,8 +164,7 @@ const dataview = new dhx.DataView("dataview_container", {height: "400px"});
 
 **Related sample**: [Dataview. Configure gap size](https://snippet.dhtmlx.com/ozsuww1q)
 
-It is possible to add margins around DataView items to increase distance between two items as well as between an item and DataView borders. Use the [](dataview/api/dataview_gap_config.md) configuration property 
-to define the desired margin:
+You can add margins around DataView items to increase the distance between two items and between an item and the DataView borders. Use the [](dataview/api/dataview_gap_config.md) configuration property to set the margin:
 
 ~~~js
 const dataview = new dhx.DataView("dataview_container", {itemsInRow: 4, gap: 20});
@@ -173,14 +174,14 @@ const dataview = new dhx.DataView("dataview_container", {itemsInRow: 4, gap: 20}
 
 ![DHTMLX DataView with several item cards highlighted by multiple selection in DHTMLX Suite](/img/dataview/multiselection.png)
 
-By default, you can select only one item in a dataview, since selection of another item resets selection of the previous one. To enable the possbility to select several DataView items, make use of the [](dataview/api/dataview_multiselection_config.md) configuration option:
+The default DataView configuration allows only one selected item: selecting another item resets the previous selection. To select several DataView items, use the [](dataview/api/dataview_multiselection_config.md) configuration option:
 
 ~~~js
 const dataview = new dhx.DataView("dataview_container", {multiselection:true});
 ~~~
 
-Setting the **multiselection** property to *true* presupposes selection of multiple items by using Ctrl key.
-It is also possible to use the "Ctrl+click" combination to select several items. For this, you need to set the [](dataview/api/dataview_multiselection_config.md) configuration option to *"ctrlClick"*:
+Set the `multiselection` property to `true` to select multiple items with the Ctrl key.
+To select several items with Ctrl+click, set the [](dataview/api/dataview_multiselection_config.md) configuration option to `"ctrlClick"`:
 
 ~~~js
 const dataview = new dhx.DataView("dataview_container", {
@@ -196,7 +197,7 @@ const dataview = new dhx.DataView("dataview_container", {
 
 **Related sample**: [Dataview. Amount items in a row](https://snippet.dhtmlx.com/de4r8km3)
 
-You can define the number of items that should be displayed in a row of DataView with the help of the [](dataview/api/dataview_itemsinrow_config.md) configuration property:
+You can define the number of items in a DataView row with the [](dataview/api/dataview_itemsinrow_config.md) configuration property:
 
 ~~~js
 const dataview = new dhx.DataView("dataview_container", {itemsInRow: 5});
@@ -206,7 +207,7 @@ const dataview = new dhx.DataView("dataview_container", {itemsInRow: 5});
 
 ![DHTMLX DataView grid of animal cards with no item selected in DHTMLX Suite](/img/dataview/disable_selection.png)
 
-The default configuration of DataView provides you with the selection feature that allows highlighting a DataView item. To disable selection in a DataView you need to set the [](dataview/api/dataview_selection_config.md) configuration property to *false*:
+The default DataView configuration highlights a selected item. To disable selection, set the [](dataview/api/dataview_selection_config.md) configuration property to `false`:
 
 ~~~js
 const dataview = new dhx.DataView("dataview_container", {
@@ -220,9 +221,9 @@ const dataview = new dhx.DataView("dataview_container", {
 
 **Related sample**: [Dataview. With template](https://snippet.dhtmlx.com/d6l6grr7)
 
-You can define a template for rendering items in a dataview with the help of the [](dataview/api/dataview_template_config.md) configuration property. You need to set a function as its value and pass one parameter to it:
+You can define a template for items in a dataview with the [](dataview/api/dataview_template_config.md) configuration property. Set a function as its value; the function takes one parameter:
 
-- **item** - (*object*) an object of a data item
+- `item` — (`object`) a data item
 
 ~~~js
 const dataview = new dhx.DataView("dataview_container", {
@@ -240,7 +241,7 @@ const dataview = new dhx.DataView("dataview_container", {
 
 ## Event handlers for the template
 
-Starting from v7.0, it is possible to assign event handlers to the HTML elements of a custom template of DataView items by using the [](dataview/api/dataview_eventhandlers_config.md) configuration option:
+From v7.0, you can assign event handlers to the HTML elements in a custom template for DataView items. Use the [](dataview/api/dataview_eventhandlers_config.md) configuration option:
 
 ~~~js {12-23}
 function template(item) {

--- a/docs/dataview/customization.md
+++ b/docs/dataview/customization.md
@@ -8,15 +8,15 @@ description: You can explore the customization of DataView in the documentation 
 
 ## Custom styling of widget
 
-There is a possibility to make changes in the look and feel of a dataview. 
+You can change the appearance of a DataView.
 
 ![DHTMLX DataView with a dark custom theme applied to item cards in DHTMLX Suite](/img/dataview/custom_widget_styles.png)
 
 **Related sample**: [Dataview. Styling (custom CSS)](https://snippet.dhtmlx.com/j1yv94o8)
 
-For this you need to take the following steps:
+Follow these steps:
 
-- add a new CSS class(es) with desired settings in the &lt;style&gt; section of your HTML page or in your file with styles (don't forget to include your file on the page in this case):
+- Add one or more CSS classes with the settings you need. Place them in the `<style>` section of your HTML page or in a separate stylesheet, and include that file on the page:
 
 ~~~html
 <style>
@@ -30,7 +30,7 @@ For this you need to take the following steps:
 </style>
 ~~~
 
-- specify the name of the created CSS class (or names of classes separated by spaces) as the value of the [](dataview/api/dataview_css_config.md) property in the DataView configuration:
+- Specify the name of the class you created (or several names separated by spaces) as the value of the [](dataview/api/dataview_css_config.md) property in the DataView configuration:
 
 ~~~js
 const dataview = new dhx.DataView("dataview_container", { 
@@ -64,7 +64,7 @@ For example:
 
 ## Custom styling of items
 
-You can style particular cells in the dataview. For example, apply some color to each even item, as in:
+You can style particular items in the dataview. For example, apply a color to every even item:
 
 ~~~html
 <style>
@@ -85,7 +85,7 @@ You can style particular cells in the dataview. For example, apply some color to
 </script>
 ~~~
 
-The image below and the related sample demonstrate another example of customization of Dataview items:
+The image below and the related sample show another way to customize DataView items:
 
 ![DHTMLX DataView with numbered item cards styled with custom green borders in DHTMLX Suite](/img/dataview/custom_items_styles.png)
 
@@ -93,8 +93,7 @@ The image below and the related sample demonstrate another example of customizat
 
 ## Custom styling of selection and focus
 
-You can apply your own styles for selection of items and focus with the help of the corresponding CSS classes: **.dhx_dataview-item--selected** and **.dhx_dataview-item--focus**. There is no need to use any
-additional custom classes.
+You can style selected and focused items with the `.dhx_dataview-item--selected` and `.dhx_dataview-item--focus` CSS classes. You do not need additional custom classes.
 
 ~~~html
 <style>

--- a/docs/dataview/data_loading.md
+++ b/docs/dataview/data_loading.md
@@ -6,22 +6,22 @@ description: You can explore the data loading of DataView in the documentation o
 
 # Data loading
 
-There are several ways of loading DataView items:
+You can load DataView items in two ways:
 
-- on initialization of DataView
-- after initialization of DataView
+- During DataView initialization
+- After DataView initialization
 
-First, you need to prepare a data set that will be loaded into DataView.
+Both ways start from a prepared data set.
 
 ## Preparing data set
 
-DHTMLX DataView expects loaded data in the JSON format. 
+DHTMLX DataView expects data in JSON format.
 
 :::info
-Please note that if you specify the `id` fields in the data collection, their values should be **unique**. You can also omit the `id` fields in the data collection. In this case they will be generated automatically.
+If you specify `id` fields in the data collection, their values must be **unique**. You can also omit these fields. In this case DataView generates the values automatically.
 :::
 
-Here is an example of an appropriate data set:
+The following data set is valid:
 
 ~~~js
 const dataset = [
@@ -43,15 +43,15 @@ const dataset = [
 ]
 ~~~
 
-Each object in the data set contains a number of *key:value* pairs that represent attributes of DataView items. 
+Each object in the data set contains `key:value` pairs that define DataView item attributes.
 
 :::note
-You can specify your own template of rendering DataView items with the help of the [](dataview/api/dataview_template_config.md) configuration option.
+Use the [](dataview/api/dataview_template_config.md) configuration option to define your own template for DataView items.
 :::
 
 ## Loading data on initialization
 
-You can load [a predefined data set](#preparing-data-set) into DataView on the initialization stage. Use the [data](dataview/api/dataview_data_config.md) configuration property, as in:
+You can load [a predefined data set](#preparing-data-set) into DataView during initialization. Use the [data](dataview/api/dataview_data_config.md) configuration property:
 
 ~~~js
 const dataview = new dhx.DataView("dataview_container", {
@@ -67,14 +67,14 @@ const dataview = new dhx.DataView("dataview_container", {
 
 ## Loading data after initialization
 
-There are two ways to load data into Combobox after its initialization:
+You can load data into DataView after initialization in two ways:
 
-- [from an external file](#external-data-loading)
-- [from a local data source](#loading-from-local-source)
+- [From an external file](#external-data-loading)
+- [From a local data source](#loading-from-local-source)
 
 ### External data loading
 
-To load data from an external file, make use of the **load()** method of [DataCollection](/data_collection/). It takes the URL of the file with data as a parameter:
+The `load()` method of [DataCollection](/data_collection/) loads data from an external file. The method takes the URL of the data file as a parameter:
 
 ~~~js
 const dataview = new dhx.DataView("dataview_container");
@@ -83,9 +83,9 @@ dataview.data.load("../common/dataset.json");
 
 **Related sample**: [Dataview. Initialization with data.load()](https://snippet.dhtmlx.com/7rjmp5ol)
 
-The component will make an AJAX call and expect the remote URL to provide valid JSON data.
+The component makes an AJAX call and expects the remote URL to return valid JSON data.
 
-Data loading is asynchronous, so you need to wrap any after-loading code into a promise:
+DataView loads data asynchronously, so place the code that depends on the loaded data into the `then()` callback:
 
 ~~~js
 dataview.data.load("/some/data").then(function(){
@@ -95,7 +95,7 @@ dataview.data.load("/some/data").then(function(){
 
 ### Loading from local source
 
-To load data from a local data source, use the **parse()** method of [DataCollection](/data_collection/). Pass [a predefined data set](#preparing-data-set) as a parameter of this method:
+The `parse()` method of [DataCollection](/data_collection/) loads data from a local data source. Pass [a predefined data set](#preparing-data-set) to this method:
 
 ~~~js
 const dataview = new dhx.DataView("dataview_container");
@@ -106,18 +106,17 @@ dataview.data.parse(dataset);
 
 ## Saving and restoring state
 
-To save the current state of a dataview, use the **serialize()** method of [DataCollection](/data_collection/). It converts the data of a dataview into an array of JSON objects. 
-Each JSON object contains a set of *key:value* pairs that represent attributes of DataView items.
+The `serialize()` method of [DataCollection](/data_collection/) saves the current state of a DataView. The method converts DataView data into an array of JSON objects. Each JSON object contains `key:value` pairs that define DataView item attributes.
 
 ~~~js
-const state = dataview1.data.serialize();
+const state = dataview.data.serialize();
 ~~~
 
-Then you can parse the data stored in the saved state array to a different dataview. For example:
+You can parse the saved state array into a different DataView:
 
 ~~~js
 // creating a new dataview
 const dataview2 = new dhx.DataView(document.body);
-// parsing the state of dataview1 into dataview2
+// parsing the state of dataview into dataview2
 dataview2.data.parse(state);
 ~~~

--- a/docs/dataview/events.md
+++ b/docs/dataview/events.md
@@ -8,17 +8,17 @@ description: You can explore the event handling of DataView in the documentation
 
 ## Attaching event listeners
 
-The user can add any user-defined handler to any of the available events. To do this, the user can use the **dataview.events.on()** method with the following parameters:
+You can add a custom handler to any available event with the `dataview.events.on()` method. The method takes the following parameters:
 
 <table>
     <tbody>
         <tr>
             <td><b>evName</b></td>
-            <td>name of the event</td>
+            <td>the event name</td>
         </tr>
         <tr>
             <td><b>evHandler</b></td>
-            <td>user-defined event handler</td>
+            <td>a custom event handler</td>
         </tr>
     </tbody>
 </table>
@@ -29,17 +29,17 @@ dataview.events.on("click", function(id, e){
 });
 ~~~
 
-Several handlers can be attached to one and the same event, and all of them will be executed.
+You can attach several handlers to the same event, and DataView runs all of them.
 
-{{note 
-The names of the events are case-insensitive.
-}}
+:::note
+Event names are case-insensitive.
+:::
 
 **Related sample**: [Dataview. Events](https://snippet.dhtmlx.com/2d74uyoh)
 
 ## Detaching event listeners
 
-There is a simple way of removing an event handler via the **dataview.events.detach()** method:
+The `dataview.events.detach()` method removes an event handler:
 
 ~~~js
 dataview.events.on("click", function(id, e){
@@ -51,7 +51,7 @@ dataview.events.detach("click");
 
 ## Calling events
 
-To call events, use **dataview.events.fire()**:
+The `dataview.events.fire()` method calls an event:
 
 ~~~js
 dataview.events.fire("name",args);
@@ -60,4 +60,4 @@ dataview.events.fire("name",args);
 
 ## List of supported events
 
-You can find the full list of Dataview events in the [API Reference](dataview/api/api_overview.md#events).
+You can find the full list of DataView events in the [API Reference](dataview/api/api_overview.md#events).

--- a/docs/dataview/features.md
+++ b/docs/dataview/features.md
@@ -6,11 +6,11 @@ description: You can explore the features of DataView in the documentation of th
 
 # Features
 
-This page contains structured information that will help you to start working with DHTMLX DataView and go into deep dive on its functionality.
+This page helps you start working with DHTMLX DataView and explore its functionality in depth.
 
 ## How to start with DHTMLX DataView
 
-In this section you can find out how to initialize DataView, how to load data into the component and how to integrate DataView into your applications.
+In this section you will learn how to initialize DataView, load data into it, and integrate it into your applications.
 
 ### Initialization
 
@@ -24,9 +24,9 @@ In this section you can find out how to initialize DataView, how to load data in
 
 | Topic                                                                              | Description                                                     |
 | ---------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| [Loading data into DataView](dataview/data_loading.md)                                     | Read how to load the initial data into DataView                 |
+| [Loading data into DataView](dataview/data_loading.md)                                     | Learn how to load the initial data into DataView                 |
 | [Initialization with config.data](https://snippet.dhtmlx.com/s547z4xr)             | The example shows how to load data into DataView on the fly     |
-| [Initialization with data.load()](https://snippet.dhtmlx.com/7rjmp5ol)             | The example shows how to load data from external file           |
+| [Initialization with data.load()](https://snippet.dhtmlx.com/7rjmp5ol)             | The example shows how to load data from an external file           |
 | [Initialization with data.parse()](https://snippet.dhtmlx.com/shhsmgrq)            | The example shows how to load data from a local data source     |
 | [Initialization with external DataCollection](https://snippet.dhtmlx.com/t632x22i) | The example shows how to load data from external DataCollection |
 
@@ -34,8 +34,8 @@ In this section you can find out how to initialize DataView, how to load data in
 
 | Topic                                                   | Description                                                                                                                                  |
 | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Backend integration](integration/suite_and_backend.md) | Learn how to connect DHTMLX Suite to a backend  ([Demo](https://github.com/DHTMLX/nodejs-suite-demo))                                        |
-| [Optimus](/optimus_guides/)                            | Learn how to use DHTMLX Optimus framework for creating  DHTMLX-based app <br>(recommended framework for creating apps with Suite components) |
+| [Backend integration](integration/suite_and_backend.md) | Learn how to connect DHTMLX Suite to a backend ([Demo](https://github.com/DHTMLX/nodejs-suite-demo))                                        |
+| [Optimus](/optimus_guides/)                            | Learn how to use the DHTMLX Optimus framework to build DHTMLX-based apps <br>(the recommended framework for apps with Suite components) |
 | [React integration](integration/suite_and_react.md)     | Learn how to use DHTMLX DataView with React ([Demo](https://github.com/DHTMLX/react-suite-demo))                                                |
 | [Angular integration](integration/suite_and_angular.md) | Learn how to use DHTMLX DataView with Angular ([Demo](https://github.com/DHTMLX/angular-suite-demo))                                         |
 | [Vue integration](integration/suite_and_vue.md)         | Learn how to use DHTMLX DataView with Vue.js ([Demo](https://github.com/DHTMLX/vue-suite-demo))                                              |
@@ -43,7 +43,7 @@ In this section you can find out how to initialize DataView, how to load data in
 
 ## How to configure DataView
 
-In this section you will know how to configure the drag-n-drop functionality, how to activate the ability to use key navigation, and more.
+In this section you will learn how to configure drag-n-drop, enable key navigation, and more.
 
 | Topic                                                                              | Description                                                                                                                            |
 | ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
@@ -51,47 +51,47 @@ In this section you will know how to configure the drag-n-drop functionality, ho
 | [Copying items during drag-n-drop](dataview/configuration.md#copying-dragged-item)         | Learn how to copy an item to a target during drag-n-drop ([Example](https://snippet.dhtmlx.com/h89c3gl3))                              |
 | [Enabling/disabling key navigation](dataview/configuration.md#arrow-keys-navigation)       | Learn how to enable/disable key navigation ([Example](https://snippet.dhtmlx.com/u7mgoly9))                                            |
 | [Activating inline editing](dataview/configuration.md#editing-items)                       | Learn how to enable inline editing on DataView initialization ([Example](https://snippet.dhtmlx.com/m8fbqcza))                         |
-| [Configuring amount of items in a row](dataview/configuration.md#number-of-items-in-a-row) | Learn how to define the number of items that should be displayed in a row of DataView ([Example](https://snippet.dhtmlx.com/de4r8km3)) |
+| [Configuring amount of items in a row](dataview/configuration.md#number-of-items-in-a-row) | Learn how to define the number of items in a DataView row ([Example](https://snippet.dhtmlx.com/de4r8km3)) |
 
 ## How to customize DataView and change its size
 
-In this section you can learn how to configure the height and style of DataView and its items.
+In this section you will learn how to configure the height and style of DataView and its items.
 
 | Topic                                                                                      | Description                                                                                                                                                                                                                                                                                                                      |
 | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Height of DataView](dataview/configuration.md#height-of-the-dataview)                             | Learn how to set the height for DataView ([Example](https://snippet.dhtmlx.com/g1k2l4q0))                                                                                                                                                                                                                                        |
-| [Height of an item](dataview/configuration.md#height-of-an-item)                                   | Learn how to set the height for DataView items ([Example](https://snippet.dhtmlx.com/cth9mwrf))                                                                                                                                                                                                                                  |
-| [Setting template for rendering items](dataview/configuration.md#template-for-dataview-items)      | Learn how [to define a template](dataview/configuration.md#template-for-dataview-items) for rendering items in a dataview ([Example](https://snippet.dhtmlx.com/d6l6grr7)) and add [event handlers](dataview/configuration.md#event-handlers-for-the-template) to HTML elements of the template ([Example](https://snippet.dhtmlx.com/26873eql)) |
+| [Height of DataView](dataview/configuration.md#height-of-the-dataview)                             | Learn how to set the height of a DataView ([Example](https://snippet.dhtmlx.com/g1k2l4q0))                                                                                                                                                                                                                                        |
+| [Height of an item](dataview/configuration.md#height-of-an-item)                                   | Learn how to set the height of DataView items ([Example](https://snippet.dhtmlx.com/cth9mwrf))                                                                                                                                                                                                                                  |
+| [Setting template for rendering items](dataview/configuration.md#template-for-dataview-items)      | Learn how to [define a template](dataview/configuration.md#template-for-dataview-items) for items in a DataView ([Example](https://snippet.dhtmlx.com/d6l6grr7)) and add [event handlers](dataview/configuration.md#event-handlers-for-the-template) to the HTML elements in it ([Example](https://snippet.dhtmlx.com/26873eql)) |
 | [Setting margins for items](dataview/configuration.md#margins-around-dataview-items)               | Learn how to set margins around DataView items ([Example](https://snippet.dhtmlx.com/ozsuww1q))                                                                                                                                                                                                                                  |
 | [Styling DataView items](dataview/customization.md#custom-styling-of-items)                        | Learn how to customize DataView items ([Example](https://snippet.dhtmlx.com/kpnzizbf))                                                                                                                                                                                                                                           |
 | [Styling selected DataView items](dataview/customization.md#custom-styling-of-selection-and-focus) | Learn how to add custom style to the selected items ([Example](https://snippet.dhtmlx.com/n98tzmzp))                                                                                                                                                                                                                             |
 | [Styling DataView](dataview/customization.md#custom-styling-of-widget)                             | Learn how to customize DataView ([Example](https://snippet.dhtmlx.com/j1yv94o8))                                                                                                                                                                                                                                                 |
-| [CSS template A](https://snippet.dhtmlx.com/dataview_template_a)                           | The example of a CSS template for DHTMLX DataView                                                                                                                                                                                                                                                                                |
-| [CSS template B](https://snippet.dhtmlx.com/dataview_template_b)                           | The example of a CSS template for DHTMLX DataView                                                                                                                                                                                                                                                                                |
-| [CSS template C](https://snippet.dhtmlx.com/dataview_template_c)                           | The example of a CSS template for DHTMLX DataView                                                                                                                                                                                                                                                                                |
-| [CSS template D](https://snippet.dhtmlx.com/dataview_template_d)                           | The example of a CSS template for DHTMLX DataView                                                                                                                                                                                                                                                                                |
-| [CSS template E](https://snippet.dhtmlx.com/dataview_template_e)                           | The example of a CSS template for DHTMLX DataView                                                                                                                                                                                                                                                                                |
-| [List of CSS classes](helpers/base_elements.md)                                        | A set of CSS classes provided by the DHTMLX library                                                                                                                                                                                                                                                                              |
+| [CSS template A](https://snippet.dhtmlx.com/dataview_template_a)                           | An example of a CSS template for DHTMLX DataView                                                                                                                                                                                                                                                                                |
+| [CSS template B](https://snippet.dhtmlx.com/dataview_template_b)                           | An example of a CSS template for DHTMLX DataView                                                                                                                                                                                                                                                                                |
+| [CSS template C](https://snippet.dhtmlx.com/dataview_template_c)                           | An example of a CSS template for DHTMLX DataView                                                                                                                                                                                                                                                                                |
+| [CSS template D](https://snippet.dhtmlx.com/dataview_template_d)                           | An example of a CSS template for DHTMLX DataView                                                                                                                                                                                                                                                                                |
+| [CSS template E](https://snippet.dhtmlx.com/dataview_template_e)                           | An example of a CSS template for DHTMLX DataView                                                                                                                                                                                                                                                                                |
+| [List of CSS classes](helpers/base_elements.md)                                        | The CSS classes included in the DHTMLX library                                                                                                                                                                                                                                                                              |
 
 ## How to work with data in DataView
 
-This section will tell you how to use [DataCollection API](guides/datacollection_guide.md) for working with data of DataView, i.e. edit, add, remove, sort data, etc.
+In this section you will learn how to use the [DataCollection API](guides/datacollection_guide.md) to work with DataView data — edit, add, remove, and sort it.
 
 ### How to edit, add, remove data
 
-In this section you may study how to add new data items into DataView, how to edit, update, or remove the items.
+In this section you will learn how to add new data items to DataView and how to edit, update, or remove them.
 
 | Topic                                                                  | Description                                                                                       |
 | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| [Editing item's data](dataview/manipulating_data.md#editing-items)             | Learn how to edit an item by its id ([Example](https://snippet.dhtmlx.com/i09isp2d))              |
-| [Adding an item](dataview/manipulating_data.md#adding-items-into-dataview)     | Learn how to add a new item into data collection ([Example](https://snippet.dhtmlx.com/k4sbj47b)) |
-| [Updating an item](dataview/manipulating_data.md#updating-dataview-items)      | Learn how to update data of an item ([Example](https://snippet.dhtmlx.com/we9vm6iz))          |
-| [Removing an item](dataview/manipulating_data.md#removing-items-from-dataview) | Learn how to remove an item from data collection ([Example](https://snippet.dhtmlx.com/i5cjuj2y)) |
-| [DataCollection API](/data_collection/)                                       | Check the list of all available DataCollection API|
+| [Editing item data](dataview/manipulating_data.md#editing-items)             | Learn how to edit an item by its id ([Example](https://snippet.dhtmlx.com/i09isp2d))              |
+| [Adding an item](dataview/manipulating_data.md#adding-items-into-dataview)     | Learn how to add a new item to the data collection ([Example](https://snippet.dhtmlx.com/k4sbj47b)) |
+| [Updating an item](dataview/manipulating_data.md#updating-dataview-items)      | Learn how to update item data ([Example](https://snippet.dhtmlx.com/we9vm6iz))          |
+| [Removing an item](dataview/manipulating_data.md#removing-items-from-dataview) | Learn how to remove an item from the data collection ([Example](https://snippet.dhtmlx.com/i5cjuj2y)) |
+| [DataCollection API](/data_collection/)                                       | Check the full DataCollection API reference |
 
 ### How to sort and filter data
 
-In this section you may study how to sort and filter data.
+In this section you will learn how to sort and filter data.
 
 | Topic                                                            | Description                                                                         |
 | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
@@ -101,56 +101,56 @@ In this section you may study how to sort and filter data.
 
 ## How to work with selection
 
-In this section you may study how to work with selection functionality.
+In this section you will learn how to work with selection.
 
 | Topic                                                                                  | Description                                                                                                                                                                                                            |
 | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Enabling/disabling selection](dataview/configuration.md#selection-of-items)                   | Learn how to enable/disable selection on DataView initialization                                                                                                                                                       |
 | [Enabling/disabling multiselection](dataview/configuration.md#multiple-selection-of-items)     | Learn how to enable/disable selection of multiple items ([Example](https://snippet.dhtmlx.com/g0xwdx10))                                                                                                               |
-| [Enabling/disabling selection](dataview/usage_selection.md#enablingdisabling-selection-object) | Learn how to enable/disable the ability to select items via the selection object ([Example](https://snippet.dhtmlx.com/kn42gb50))                                                                                      |
+| [Enabling/disabling the selection object](dataview/usage_selection.md#enablingdisabling-selection-object) | Learn how to enable or disable item selection through the selection object ([Example](https://snippet.dhtmlx.com/kn42gb50))                                                                                      |
 | [Setting selection](dataview/usage_selection.md#selecting-an-item)                             | Learn how to select a particular item or all items ([Example](https://snippet.dhtmlx.com/8li8wi20))                                                                                                                    |
-| Getting selection                                                                      | Learn how to get the [id](dataview/usage_selection.md#getting-id-of-a-selected-item) or an [object](dataview/usage_selection.md#getting-object-of-a-selected-item) of a selected item ([Example](https://snippet.dhtmlx.com/uop0vy8u)) |
-| [Removing selection](dataview/usage_selection.md#unselecting-an-item)                          | Learn how to remove selection from a selected item(s)                                                                                                                                                                  |
+| Getting selection                                                                      | Learn how to get the [id](dataview/usage_selection.md#getting-id-of-a-selected-item) or the [object](dataview/usage_selection.md#getting-object-of-a-selected-item) of a selected item ([Example](https://snippet.dhtmlx.com/uop0vy8u)) |
+| [Removing selection](dataview/usage_selection.md#unselecting-an-item)                          | Learn how to remove selection from selected items                                                                                                                                                                  |
 
 ## How to work with item in focus
 
-In this section you will learn how to set focus on an item and get the id/object of an item in focus.
+In this section you will learn how to set focus on an item and get the id or the object of an item in focus.
 
 | Topic                                                                | Description                                                                                                                          |
 | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | [Setting focus on item](dataview/manipulating_data.md#setting-focus-on-item) | Learn how to set focus on an item ([Example](https://snippet.dhtmlx.com/4l38pct7))                                                   |
-| Getting an item in focus                                             | Learn how to get the [id](dataview/api/dataview_getfocus_method.md) or an [object](dataview/api/dataview_getfocusitem_method.md) of an item in focus |
+| Getting an item in focus                                             | Learn how to get the [id](dataview/api/dataview_getfocus_method.md) or the [object](dataview/api/dataview_getfocusitem_method.md) of an item in focus |
 
 ## How to work with DataView events
 
-This section explains how to work with DataView events.
+In this section you will learn how to work with DataView events.
 
 | Topic                                       | Description                                                                                               |
 | :------------------------------------------ | :-------------------------------------------------------------------------------------------------------- |
-| [Event basic rules](guides/events_guide.md) | Learn basic rules on how to work with events                                                              |
-| [Event handling](dataview/events.md)       | Learn how to attach, detach, or call the DataView events ([Example](https://snippet.dhtmlx.com/2d74uyoh)) |
+| [Event basic rules](guides/events_guide.md) | Learn the basic rules of event handling                                                              |
+| [Event handling](dataview/events.md)       | Learn how to attach, detach, or call DataView events ([Example](https://snippet.dhtmlx.com/2d74uyoh)) |
 
 ## API reference
 
-In this section you can find out corresponding references of DataView API.
+In this section you will find the DataView API reference.
 
 | Topic                                                      | Description                                                |
 | ---------------------------------------------------------- | ---------------------------------------------------------- |
 | [DataView methods](/category/dataview-methods/)       | Check the list of DataView methods                         |
 | [DataView events](/category/dataview-events/)         | Check the list of DataView events                          |
 | [DataView properties](/category/dataview-properties/) | Check the list of DataView properties                      |
-| [DataCollection API](/data_collection/)               | Check the API of DataCollection to work with DataView data |
+| [DataCollection API](/data_collection/)               | Check the DataCollection API for working with DataView data |
 
 ## Common functionality
 
-In this section you will learn about common functionality of the library which can be useful while working with DataView.
+In this section you will learn about common library functionality that is useful when you work with DataView.
 
 | Topic                                                         | Description                                                   |
 | ------------------------------------------------------------- | ------------------------------------------------------------- |
 | [Touch support](common_features/touch_support.md)         | Learn how to work with touch support                          |
 | [TypeScript support](common_features/using_typescript.md) | Learn how to work with TypeScript                             |
 | [Custom scroll](common_features/custom_scroll.md)         | Learn how to use custom scroll in DataView                    |
-| [AwaitRedraw](helpers/await_redraw.md)                    | Learn how to perform the code after the component’s rendering |
+| [AwaitRedraw](helpers/await_redraw.md)                    | Learn how to run code after the component renders |
 
 ## Any questions left?
 

--- a/docs/dataview/index.md
+++ b/docs/dataview/index.md
@@ -6,15 +6,15 @@ description: You can have an overview of DataView in the documentation of the DH
 
 # DataView overview
 
-DHTMLX DataView allows rendering a collection of objects according to a specified template. It will help you to organize data by arranging various objects with similar properties within a common container.
-This component is especially useful, if you're creating an online store or an image gallery, or just want to display a number of similar objects on a page.
-Check [online samples for DHTMLX DataView](https://snippet.dhtmlx.com/j1yv94o8?tag=dataview). 
+DHTMLX DataView renders a collection of objects according to a specified template. The component arranges objects with similar properties in a common container and keeps your data organized.
+DataView is especially useful if you build an online store or an image gallery, or want to display a set of similar objects on a page.
+Check [online samples for DHTMLX DataView](https://snippet.dhtmlx.com/j1yv94o8?tag=dataview).
 
 ![DHTMLX DataView showing animal cards with photos titles and descriptions in a grid in DHTMLX Suite](/img/dataview/dataview_front.png)
 
 ## Features
 
-You can check the following page to learn how to build a full-featured DHTMLX DataView:
+Check the following page to learn how to build a full-featured DHTMLX DataView:
 
 - [Features](dataview/features.md)
 
@@ -24,13 +24,13 @@ You can check the following page to learn how to build a full-featured DHTMLX Da
 
 ## Related resources
 
-- You can get DHTMLX DataView as a part of the Suite library by [downloading DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml)
-- There are also [online samples for DHTMLX DataView](https://snippet.dhtmlx.com/j1yv94o8?tag=dataview)
-- To work with data of DataView check [DataCollection API](/data_collection/)
+- [Download DHTMLX Suite](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) to get DHTMLX DataView as part of the Suite library
+- Browse [online samples for DHTMLX DataView](https://snippet.dhtmlx.com/j1yv94o8?tag=dataview)
+- Check the [DataCollection API](/data_collection/) to work with DataView data
 
 ## Guides
 
-You can read the following articles to find out how to add DataView on the page and work with it.
+The following articles explain how to add DataView to a page and work with it.
 
 - [](dataview/initialization.md)
 - [](dataview/configuration.md)

--- a/docs/dataview/initialization.md
+++ b/docs/dataview/initialization.md
@@ -7,14 +7,14 @@ description: You can explore the initialization of DataView in the documentation
 # Initialization
 
 :::info
-[Download the DHTMLX DataView package](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) as a part of the DHTMLX Suite library
+[Download the DHTMLX DataView package](https://dhtmlx.com/docs/products/dhtmlxSuite/download.shtml) as part of the DHTMLX Suite library.
 :::
 
-To initialize DHTMLX DataView on a page, you need to take the following simple steps:
+Follow these steps to initialize DHTMLX DataView on a page:
 
 - [Include source files](#include-source-files)
 - [Create a container](#create-a-container)
-- [Initialize DataView](#initialize-dataview) with the object constructor
+- [Initialize DataView](#initialize-dataview) with the constructor
 - [Load data into DataView](#load-data-into-dataview)
 
 ~~~html title="index.html"
@@ -39,12 +39,12 @@ To initialize DHTMLX DataView on a page, you need to take the following simple s
 
 ## Include source files
 
-Unpack the downloaded package into a folder of your project.
+Unpack the downloaded package into your project folder.
 
-After that, create an HTML file and place full paths to JS and CSS files of the DHTMLX Suite library into the header of the file. The files are:
+Create an HTML file and add the full paths to the JS and CSS files of the DHTMLX Suite library in its header. The files are:
 
-- *suite.js*
-- *suite.css*
+- `suite.js`
+- `suite.css`
 
 ~~~html title="index.html"
 <script type="text/javascript" src="../../codebase/suite.js"></script>
@@ -53,7 +53,7 @@ After that, create an HTML file and place full paths to JS and CSS files of the 
 
 ## Create a container
 
-Add a container for DataView and give it an id, for example "dataview_container":
+Add a container for DataView and give it an id, for example `dataview_container`:
 
 ~~~html title="index.html"
 <div id="dataview_container"></div>
@@ -61,10 +61,10 @@ Add a container for DataView and give it an id, for example "dataview_container"
 
 ## Initialize DataView
 
-Initialize DataView with the `dhx.DataView` object constructor. The constructor has two parameters:
+Initialize DataView with the `dhx.DataView` constructor. The constructor takes two parameters:
 
-- the HTML container for DataView,
-- optional, an object with configuration properties. If this argument is not passed to the constructor, the settings will be default.
+- The HTML container for DataView.
+- An object with configuration properties (optional). If you omit this argument, DataView uses the default settings.
 
 ~~~js title="index.js"
 // creating DHTMLX DataView
@@ -74,20 +74,18 @@ const dataview = new dhx.DataView("dataview_container", {
 ~~~
 
 :::info
-To display data in DataView you should define a [template](dataview/configuration.md#template-for-dataview-items) via the [template](dataview/api/dataview_template_config.md) configuration property.
+To display data in DataView, define a [custom template](dataview/configuration.md#template-for-dataview-items) with the [template](dataview/api/dataview_template_config.md) configuration property.
 
-Another way to display data in DataView is to prepare a data set with the ["value"](dataview/data_loading.md#preparing-data-set) attribute.
+Another way to display data in DataView is to prepare a data set with the [`value`](dataview/data_loading.md#preparing-data-set) attribute.
 :::
 
 ### Configuration properties
 
-There is a set of properties you can specify for DataView to optimize its configuration for your needs.
-
-The detailed information on DataView configuration options can be found in the [Dataview API overview](dataview/api/api_overview.md#properties) article.
+The [DataView API overview](dataview/api/api_overview.md#properties) article describes the properties you can specify to adapt DataView to your needs.
 
 ## Load data into DataView
 
-Detailed information on how to load data into DHTMLX DataView is given in the [Data loading](dataview/data_loading.md) article.
+The [Data loading](dataview/data_loading.md) article explains how to load data into DHTMLX DataView.
 
 ## Example
 

--- a/docs/dataview/manipulating_data.md
+++ b/docs/dataview/manipulating_data.md
@@ -8,7 +8,7 @@ description: You can explore how to work with DataView in the documentation of t
 
 ## Setting focus on item
 
-To set focus on a DataView item, make use of the [setFocus()](dataview/api/dataview_setfocus_method.md) method. It takes the id of an item as a parameter:
+Use the [`setFocus()`](dataview/api/dataview_setfocus_method.md) method to set focus on a DataView item. The method takes an item id as a parameter:
 
 ~~~js
 dataview.setFocus("7");
@@ -16,7 +16,7 @@ dataview.setFocus("7");
 
 ## Editing items
 
-You can edit a particular DataView item with the help of the [editItem()](dataview/api/dataview_edititem_method.md) method. It takes as a parameter the id of an item:
+You can edit a DataView item with the [`editItem()`](dataview/api/dataview_edititem_method.md) method. The method takes an item id as a parameter:
 
 ~~~js
 dataview.editItem("1");
@@ -26,25 +26,25 @@ dataview.editItem("1");
 
 ## Disabling and enabling selection of an item
 
-For information on disabling/enabling selection of an item, read [Enabling/Disabling Selection object](dataview/usage_selection.md#enablingdisabling-selection-object).
+For details on how to disable and enable selection of an item, see [Enabling/Disabling Selection object](dataview/usage_selection.md#enablingdisabling-selection-object).
 
 ## Using Data Collection API
 
-You can manipulate DataView items with the help of the [Data Collection API](/data_collection/).
+You can manage DataView items with the [Data Collection API](/data_collection/).
 
 ### Adding items into DataView
 
-It is possible to add more items into the initialized DataView on the fly. Use the **add()** method of Data Collection. It takes two parameters:
+You can add more items to an initialized DataView on the fly. Use the `add()` method of Data Collection. The method takes two parameters:
 
 <table>
     <tbody>
         <tr>
             <td><b>config</b></td>
-            <td>(<i>object</i>) the configuration object of the added item</td>
+            <td>(<i>object</i>) the configuration object of the new item</td>
         </tr>
         <tr>
             <td><b>index</b></td>
-            <td>(<i>number</i>) optional, the position to add an item at</td>
+            <td>(<i>number</i>) optional, the position for the new item</td>
         </tr>
     </tbody>
 </table>
@@ -62,7 +62,7 @@ dataview.data.add({
 
 ### Updating DataView items
 
-You can change config options of the item via the **update()** method of Data Collection. It takes two parameters:
+You can change item settings with the `update()` method of Data Collection. The method takes two parameters:
 
 <table>
     <tbody>
@@ -72,7 +72,7 @@ You can change config options of the item via the **update()** method of Data Co
         </tr>
         <tr>
             <td><b>config</b></td>
-            <td>an object with new configuration of the item</td>
+            <td>an object with the new item configuration</td>
         </tr>
     </tbody>
 </table>
@@ -90,7 +90,7 @@ dataview.data.update("item_id",{
 
 ### Removing items from DataView
 
-To remove an item, make use of the **remove()** method of Data Collection. Pass the id of the item that should be removed to the method:
+Use the `remove()` method of Data Collection to remove an item. Pass the item id to the method:
 
 ~~~js
 dataview.data.remove("id");
@@ -100,8 +100,7 @@ dataview.data.remove("id");
 
 ### Filtering DataView data
 
-You can filter DataView data by the specified criteria with the help of the [](data_collection/api/datacollection_filter_method.md) method of Data collection. Check all details on parameters of the method in the
-[Data Collection API](/data_collection/).
+You can filter DataView data by specified criteria with the [](data_collection/api/datacollection_filter_method.md) method of Data Collection. For details on the method parameters, see the [Data Collection API](/data_collection/).
 
 ~~~js
 dataview.data.filter({
@@ -115,9 +114,9 @@ dataview.data.filter({
 
 ### Sorting DataView data
 
-It is possible to sort data in DataView via the [](data_collection/api/datacollection_sort_method.md) method of Data Collection.
+You can sort data in DataView with the [](data_collection/api/datacollection_sort_method.md) method of Data Collection.
 
-Check all details on the parameters of the method in the [Data Collection API](/data_collection/).
+For details on the method parameters, see the [Data Collection API](/data_collection/).
 
 ~~~js
 dataview.data.sort({ 
@@ -130,4 +129,4 @@ dataview.data.sort({
 
 ## Using Selection API
 
-For information on using Selection API, read [Work with Selection Object](dataview/usage_selection.md).
+For details on the Selection API, see [Work with Selection object](dataview/usage_selection.md).

--- a/docs/dataview/usage_selection.md
+++ b/docs/dataview/usage_selection.md
@@ -6,17 +6,17 @@ description: You can explore how to work with Selection Object of DataView in th
 
 # Work with Selection object
 
-You can manipulate with DataView items via the API of the **selection** object. It is possible to select an item, remove selection, and get the id or even the object of a selected DataView item.
+The `selection` object API lets you manage DataView items: select an item, remove selection, and get the id or the object of a selected DataView item.
 
 ## Enabling/Disabling Selection object
 
-Starting from v7.0, you can activate selection of items via the [enable()](selection/api/selection_enable_method.md) method of the selection object.
+From v7.0, you can enable item selection with the [`enable()`](selection/api/selection_enable_method.md) method of the `selection` object:
 
 ~~~js
 dataview.selection.enable();
 ~~~
 
-To disable selection of items in DataView, make use of the [disable()](selection/api/selection_disable_method.md) method of the selection object:
+To disable item selection in DataView, use the [`disable()`](selection/api/selection_disable_method.md) method of the `selection` object:
 
 ~~~js
 dataview.selection.disable();
@@ -24,18 +24,20 @@ dataview.selection.disable();
 
 **Related sample**: [Dataview. Disable / enable selection](https://snippet.dhtmlx.com/kn42gb50)
 
-{{note To make the process of working with the selection of items more flexible, you can apply the [related](/selection/#events) events of the Selection object.}}
+:::note
+For finer control over item selection, apply the [Selection object events](/selection/#events).
+:::
 
 ## Selecting an item
 
-To select a particular DataView item, make use of the **add()** method of the **selection** object. As a parameter the method takes the id of an item. 
+To select a DataView item, use the `add()` method of the `selection` object. The method takes an item id as a parameter:
 
 ~~~js
 const id = dataview.selection.getId(); // -> "2"
 dataview.selection.add("2");
 ~~~
 
-Starting from v7.0, the method selects all unselected items when calling without parameters:
+From v7.0, the method selects all unselected items when you call it without parameters:
 
 ~~~js
 dataview.selection.add();
@@ -43,13 +45,13 @@ dataview.selection.add();
 
 ## Unselecting an item
 
-To remove selection from a selected item, apply the **remove()** method of the **selection** object. The method may take the id of an item as a parameter:
+To remove selection from a selected item, apply the `remove()` method of the `selection` object. The method can take an item id as a parameter:
 
 ~~~js
 dataview.selection.remove("2"); 
 ~~~
 
-Starting from v7.0, the method unselects all previously selected items when calling without parameters:
+From v7.0, the method unselects all previously selected items when you call it without parameters:
 
 ~~~js
 dataview.selection.remove();
@@ -57,20 +59,20 @@ dataview.selection.remove();
 
 ## Getting id of a selected item
 
-You can get the id of the currently selected item with the **getId()** method of the **selection** object:
+You can get the id of the currently selected item with the `getId()` method of the `selection` object:
 
 ~~~js
 const selected = dataview.selection.getId(); // -> "2"
 ~~~
 
-Starting from v7.0, the method can also return an array with ids of selected items if the [multiselection](dataview/api/dataview_multiselection_config.md) property of DataView is enabled.
+From v7.0, the method can also return an array of ids of selected items if the DataView [multiselection](dataview/api/dataview_multiselection_config.md) property is enabled.
 
 ## Getting object of a selected item
 
-It is also possible to get the object of a selected item using the **getItem()** method of the **selection** object:
+You can also get the object of a selected item with the `getItem()` method of the `selection` object:
 
 ~~~js
 const item = dataview.selection.getItem();
 ~~~
 
-Starting from v7.0, the method can also return an array of selected items if the [multiselection](dataview/api/dataview_multiselection_config.md) property of DataView is enabled.
+From v7.0, the method can also return an array of selected items if the DataView [multiselection](dataview/api/dataview_multiselection_config.md) property is enabled.


### PR DESCRIPTION
- fixed two misspellings of "possibility": "possiblity" on line 75 and "possbility" on line 176
- "presupposes selection of multiple items" used the wrong verb
- replaced two legacy {{note}} macros with :::note admonitions, both were rendering literally on the page
- API values moved from italics/bold/straight quotes to backticks: true/false, function, dragMode, multiselection, ctrlClick, false, item, object, calc(), and the target/source/both drag modes
- five "provide/enable the possibility to..." wrappers collapsed into direct verbs, along with "It is possible to" twice
- dropped "with the help of" (4x), "via" (2x), "make use of", "In order to", "as easy as that", "To begin with", "Then", and three "you should/need to" modals
- "By default" replaced with the adjective form in two places, as the rule requires
- arrow key rows said "previous/next vertical item" and "previous/next horizontal item" instead of naming the direction; now above, below, on the left, on the right
- "adds selection to an item in focus" -> "selects the focused item", "an object of a data item" -> "a data item"
- "the number of items that should be displayed in a row" turned active
- the three drag mode bullets were not parallel and the "both" one said the same thing three times
- vague link label [below] -> [Multiple selection of items]
- broke up of-chains: "in the configuration object of DataView", "the HTML elements of a custom template of DataView items"
- "several modes" -> "three modes"; removed the necessary/desired height and margin, and "some custom navigation logic"
- Dataview -> DataView in prose and in the "Height of the DataView" heading; the slug is unchanged. Related sample lines are left as is, the skill excludes them
- hyphen separators -> em dashes, removed three trailing spaces, added the missing colon before the string-value sample

Left for a decision: the shortcut table documents Enter twice, once as "Enter/Shift+Enter/Ctrl+Enter adds selection" and once as "Enter adds selection, activates editor". What a plain Enter does is unclear, and resolving it is a question about behavior, not grammar. Noticed in passing: "possiblity" also appears in list/configuration.md:60, in a nearly identical sentence about dragging several items.